### PR TITLE
Wasi clock_res_get and clock_time_get

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,16 +360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpu-time"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,15 +639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cvt"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac344c7efccb80cd25bc61b2170aec26f2f693fd40e765a539a1243db48c71"
-dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,16 +693,6 @@ name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
-dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if 1.0.0",
  "dirs-sys-next",
@@ -847,18 +818,6 @@ checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
 dependencies = [
  "env_logger 0.7.1",
  "log",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall",
- "winapi",
 ]
 
 [[package]]
@@ -1117,6 +1076,7 @@ dependencies = [
  "env_logger 0.8.2",
  "getrandom",
  "lazy_static",
+ "libc",
  "log",
  "pretty_assertions",
  "rayon",
@@ -1124,7 +1084,6 @@ dependencies = [
  "smol",
  "uptown_funk",
  "walrus",
- "wasi-common",
  "wasmer",
  "wasmer-vm",
  "wasmprinter",
@@ -1677,15 +1636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
-dependencies = [
- "dirs-next",
-]
-
-[[package]]
 name = "signal-hook"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,7 +1819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2005,26 +1954,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wasi-common"
-version = "0.22.0"
-source = "git+https://github.com/lunatic-solutions/wasmtime.git?branch=lunatic#61a38008ea01f39c9b00b3fd96f3d66d37e13532"
-dependencies = [
- "anyhow",
- "cfg-if 1.0.0",
- "cpu-time",
- "filetime",
- "getrandom",
- "lazy_static",
- "libc",
- "thiserror",
- "tracing",
- "wiggle",
- "winapi",
- "winx",
- "yanix",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2459,15 +2388,6 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1220ed7f824992b426a76125a3403d048eaf0f627918e97ade0d9b9d510d20"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wast"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d04fe175c7f78214971293e7d8875673804e736092206a3a4544dbc12811c1b"
@@ -2481,7 +2401,7 @@ version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec9c6ee01ae07a26adadcdfed22c7a97e0b8cbee9c06e0e96076ece5aeb5cfe"
 dependencies = [
- "wast 33.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -2514,42 +2434,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wiggle"
-version = "0.22.0"
-source = "git+https://github.com/lunatic-solutions/wasmtime.git?branch=lunatic#61a38008ea01f39c9b00b3fd96f3d66d37e13532"
-dependencies = [
- "bitflags",
- "thiserror",
- "tracing",
- "wiggle-macro",
-]
-
-[[package]]
-name = "wiggle-generate"
-version = "0.22.0"
-source = "git+https://github.com/lunatic-solutions/wasmtime.git?branch=lunatic#61a38008ea01f39c9b00b3fd96f3d66d37e13532"
-dependencies = [
- "anyhow",
- "heck",
- "proc-macro2",
- "quote",
- "shellexpand",
- "syn",
- "witx",
-]
-
-[[package]]
-name = "wiggle-macro"
-version = "0.22.0"
-source = "git+https://github.com/lunatic-solutions/wasmtime.git?branch=lunatic#61a38008ea01f39c9b00b3fd96f3d66d37e13532"
-dependencies = [
- "quote",
- "syn",
- "wiggle-generate",
- "witx",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,39 +2463,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winx"
-version = "0.22.0"
-source = "git+https://github.com/lunatic-solutions/wasmtime.git?branch=lunatic#61a38008ea01f39c9b00b3fd96f3d66d37e13532"
-dependencies = [
- "bitflags",
- "cvt",
- "winapi",
-]
-
-[[package]]
-name = "witx"
-version = "0.8.8"
-source = "git+https://github.com/lunatic-solutions/wasmtime.git?branch=lunatic#61a38008ea01f39c9b00b3fd96f3d66d37e13532"
-dependencies = [
- "anyhow",
- "log",
- "thiserror",
- "wast 22.0.0",
-]
-
-[[package]]
-name = "yanix"
-version = "0.22.0"
-source = "git+https://github.com/lunatic-solutions/wasmtime.git?branch=lunatic#61a38008ea01f39c9b00b3fd96f3d66d37e13532"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "filetime",
- "libc",
- "tracing",
-]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-runtime",
  "wat",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ smallvec = "1.5"
 env_logger = "0.8"
 log = "0.4"
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"
+
+
 [dev-dependencies]
 criterion = "0.3"
 rayon = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ vm-wasmer = ["uptown_funk/vm-wasmer", "wasmer", "wasmer-vm"]
 [dependencies]
 async-wormhole = "0.3"
 uptown_funk = { version = "0.1", path = "./uptown_funk", features=["async"] }
+libc = { version = "^0.2", default-features = false }
 wasmer = { git = "https://github.com/lunatic-solutions/wasmer.git", branch = "lunatic", optional = true }
 wasmer-vm = { git = "https://github.com/lunatic-solutions/wasmer.git", branch = "lunatic", optional = true }
 wasmtime = { git = "https://github.com/lunatic-solutions/wasmtime.git", branch = "lunatic", optional = true }
 wasmtime-runtime = { git = "https://github.com/lunatic-solutions/wasmtime.git", branch = "lunatic", optional = true }
 clap = "3.0.0-beta.2"
-wasi-common = { git = "https://github.com/lunatic-solutions/wasmtime.git", branch = "lunatic" }
 getrandom = { version = "0.2.0", features = ["std"] }
 walrus = "0.18"
 smol = "1.2"

--- a/src/wasi/api/unix.rs
+++ b/src/wasi/api/unix.rs
@@ -1,0 +1,70 @@
+// NOTE: implementation borrowed from https://github.com/wasmerio/wasmer/blob/0ab8a0de096ffdf89f353dd722a15b5e6255055f/lib/wasi/src/syscalls/unix/mod.rs
+
+use super::super::types::*;
+use libc::{
+    clock_getres, clock_gettime, timespec, CLOCK_MONOTONIC, CLOCK_PROCESS_CPUTIME_ID,
+    CLOCK_REALTIME, CLOCK_THREAD_CPUTIME_ID,
+};
+
+use uptown_funk::types::Pointer;
+
+fn errno_to_status(err: i32) -> Status {
+    // TODO: map errno from clock_getres to types::Status
+    match err {
+        0 => Status::Success,
+        _ => Status::Inval,
+    }
+}
+
+pub fn platform_clock_res_get(clock_id: Clockid, mut res: Pointer<Timestamp>) -> Status {
+    let unix_clock_id = match clock_id {
+        Clockid::Realtime => CLOCK_MONOTONIC,
+        Clockid::Monotonic => CLOCK_PROCESS_CPUTIME_ID,
+        Clockid::ProcessCpuTimeId => CLOCK_REALTIME,
+        Clockid::ThreadCpuTimeId => CLOCK_THREAD_CPUTIME_ID,
+        Clockid::Unsupported => return Status::Inval,
+    };
+
+    let (output, timespec_out) = unsafe {
+        let mut timespec_out: timespec = timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        (clock_getres(unix_clock_id, &mut timespec_out), timespec_out)
+    };
+
+    let t_out = (timespec_out.tv_sec * 1_000_000_000).wrapping_add(timespec_out.tv_nsec);
+    res.set(t_out as Timestamp);
+
+    errno_to_status(output)
+}
+
+pub fn platform_clock_time_get(
+    clock_id: Clockid,
+    _precision: Timestamp,
+    mut time: Pointer<Timestamp>,
+) -> StatusTrapResult {
+    let unix_clock_id = match clock_id {
+        Clockid::Realtime => CLOCK_MONOTONIC,
+        Clockid::Monotonic => CLOCK_PROCESS_CPUTIME_ID,
+        Clockid::ProcessCpuTimeId => CLOCK_REALTIME,
+        Clockid::ThreadCpuTimeId => CLOCK_THREAD_CPUTIME_ID,
+        Clockid::Unsupported => return Status::Inval.into(),
+    };
+
+    let (output, timespec_out) = unsafe {
+        let mut timespec_out: timespec = timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        (
+            clock_gettime(unix_clock_id, &mut timespec_out),
+            timespec_out,
+        )
+    };
+
+    let t_out = (timespec_out.tv_sec * 1_000_000_000).wrapping_add(timespec_out.tv_nsec);
+    time.set(t_out as Timestamp);
+
+    errno_to_status(output).into()
+}

--- a/src/wasi/api/windows.rs
+++ b/src/wasi/api/windows.rs
@@ -1,0 +1,58 @@
+// NOTE: implementation borrowed from https://github.com/wasmerio/wasmer/blob/0ab8a0de096ffdf89f353dd722a15b5e6255055f/lib/wasi/src/syscalls/windows.rs
+
+use super::super::types::*;
+use std::time::{SystemTime, UNIX_EPOCH};
+use winapi::um::sysinfoapi::GetTickCount64;
+
+use uptown_funk::{types::Pointer, Trap};
+
+pub fn platform_clock_res_get(clock_id: Clockid, mut res: Pointer<Timestamp>) -> Status {
+    let resolution_val = match clock_id {
+        // resolution of monotonic clock at 10ms, from:
+        // https://docs.microsoft.com/en-us/windows/desktop/api/sysinfoapi/nf-sysinfoapi-gettickcount64
+        Clockid::Realtime => 1,
+        Clockid::Monotonic => 10_000_000,
+        // TODO: verify or compute this
+        Clockid::ProcessCpuTimeId => {
+            return Status::Inval;
+        }
+        Clockid::ThreadCpuTimeId => {
+            return Status::Inval;
+        }
+        Clockid::Unsupported => return Status::Inval,
+    };
+    res.set(resolution_val);
+    Status::Success
+}
+
+pub fn platform_clock_time_get(
+    clock_id: Clockid,
+    _precision: Timestamp,
+    mut time: Pointer<Timestamp>,
+) -> StatusTrapResult {
+    let nanos =
+        match clock_id {
+            Clockid::Realtime => {
+                let duration = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|_| Status::Io)?;
+                duration.as_nanos() as u64
+            }
+            Clockid::Monotonic => {
+                let tick_ms = unsafe { GetTickCount64() };
+                tick_ms * 1_000_000
+            }
+
+            Clockid::ProcessCpuTimeId => return Err(Trap::new(
+                "wasi::api::platform_clock_time_get(Clockid::ProcessCpuTimeId, ..) not implemented",
+            )
+            .into()),
+            Clockid::ThreadCpuTimeId => return Err(Trap::new(
+                "wasi::api::platform_clock_time_get(Clockid::ThreadCpuTimeId, ..) not implemented",
+            )
+            .into()),
+            Clockid::Unsupported => return Status::Inval.into(),
+        };
+    time.set(nanos);
+    Ok(())
+}

--- a/src/wasi/state.rs
+++ b/src/wasi/state.rs
@@ -1,6 +1,5 @@
 use super::types::{Filestat, OpenFlags, Status, StatusResult};
 use uptown_funk::StateMarker;
-use wasi_common::{WasiCtx, WasiCtxBuilder};
 
 use std::{
     fs,
@@ -14,7 +13,6 @@ use std::{
 type Fd = u32;
 
 pub struct WasiState {
-    pub ctx: WasiCtx,
     fds: Vec<Option<FileDesc>>,
 }
 
@@ -23,9 +21,7 @@ pub struct WasiState {
 impl WasiState {
     pub fn new() -> Self {
         // TODO cannot trap if open / fails
-        let ctx = WasiCtxBuilder::new().build().unwrap();
         Self {
-            ctx,
             fds: vec![None, None, None, FileDesc::open("/").ok()],
         }
     }

--- a/src/wasi/types/aliases.rs
+++ b/src/wasi/types/aliases.rs
@@ -1,7 +1,6 @@
 pub type Size = u32;
 pub type Filesize = u64;
 pub type Timestamp = u64;
-pub type Clockid = u32;
 pub type Rights = u64;
 pub type Fd = u32;
 pub type Filedelta = i64;

--- a/src/wasi/types/clock.rs
+++ b/src/wasi/types/clock.rs
@@ -1,0 +1,28 @@
+use uptown_funk::{types::CReprWasmType, Executor, FromWasm, Trap};
+
+#[derive(Copy, Clone)]
+#[repr(u32)]
+pub enum Clockid {
+    Realtime = 0,
+    Monotonic = 1,
+    ProcessCpuTimeId = 2,
+    ThreadCpuTimeId = 3,
+}
+
+impl CReprWasmType for Clockid {}
+
+impl FromWasm for Clockid {
+    type From = u32;
+    type State = ();
+
+    fn from(_: &mut (), _: &impl Executor, from: u32) -> Result<Self, Trap> {
+        match from {
+            0 => Ok(Clockid::Realtime),
+            1 => Ok(Clockid::Monotonic),
+            2 => Ok(Clockid::ProcessCpuTimeId),
+            3 => Ok(Clockid::ThreadCpuTimeId),
+            // FIXME: can I throw Status::Inval here?
+            _ => Err(Trap::new("Invalid clockid")),
+        }
+    }
+}

--- a/src/wasi/types/clock.rs
+++ b/src/wasi/types/clock.rs
@@ -7,6 +7,17 @@ pub enum Clockid {
     Monotonic = 1,
     ProcessCpuTimeId = 2,
     ThreadCpuTimeId = 3,
+    Unsupported = u32::MAX,
+}
+
+fn to_clockid(num: u32) -> Clockid {
+    match num {
+        0 => Clockid::Realtime,
+        1 => Clockid::Monotonic,
+        2 => Clockid::ProcessCpuTimeId,
+        3 => Clockid::ThreadCpuTimeId,
+        _ => Clockid::Unsupported,
+    }
 }
 
 impl CReprWasmType for Clockid {}
@@ -16,13 +27,6 @@ impl FromWasm for Clockid {
     type State = ();
 
     fn from(_: &mut (), _: &impl Executor, from: u32) -> Result<Self, Trap> {
-        match from {
-            0 => Ok(Clockid::Realtime),
-            1 => Ok(Clockid::Monotonic),
-            2 => Ok(Clockid::ProcessCpuTimeId),
-            3 => Ok(Clockid::ThreadCpuTimeId),
-            // FIXME: can I throw Status::Inval here?
-            _ => Err(Trap::new("Invalid clockid")),
-        }
+        Ok(to_clockid(from))
     }
 }

--- a/src/wasi/types/mod.rs
+++ b/src/wasi/types/mod.rs
@@ -1,21 +1,19 @@
 #![allow(dead_code)]
 
 mod aliases;
+mod clock;
 mod flags;
 mod status;
 mod structs;
 
 pub use aliases::*;
+pub use clock::*;
 pub use flags::*;
 pub use status::Status;
 pub use status::StatusResult;
 pub use status::StatusTrap;
 pub use status::StatusTrapResult;
 pub use structs::*;
-
-use uptown_funk::{Executor, FromWasm, Trap};
-// TODO remove dependency
-use wasi_common::wasi::types::Clockid;
 
 pub struct Wrap<T> {
     pub inner: T,
@@ -24,25 +22,6 @@ pub struct Wrap<T> {
 impl<T> Wrap<T> {
     fn new(inner: T) -> Self {
         Self { inner }
-    }
-}
-
-impl FromWasm for Wrap<Clockid> {
-    type From = u32;
-    type State = ();
-
-    fn from(
-        _state: &mut Self::State,
-        _executor: &impl Executor,
-        from: Self::From,
-    ) -> Result<Self, Trap>
-    where
-        Self: Sized,
-    {
-        use std::convert::TryFrom;
-        Clockid::try_from(from)
-            .map_err(|_| Trap::new("Invalid clock id"))
-            .map(|v| Wrap::new(v))
     }
 }
 

--- a/src/wasi/types/status.rs
+++ b/src/wasi/types/status.rs
@@ -283,3 +283,12 @@ impl Into<StatusResult> for Status {
         }
     }
 }
+
+impl Into<StatusTrapResult> for Status {
+    fn into(self) -> StatusTrapResult {
+        match self {
+            Status::Success => Ok(()),
+            s => Err(From::from(s)),
+        }
+    }
+}

--- a/src/wasi/types/structs.rs
+++ b/src/wasi/types/structs.rs
@@ -4,7 +4,7 @@ use std::io::{IoSlice, IoSliceMut};
 use smallvec::SmallVec;
 use uptown_funk::types::CReprWasmType;
 
-use super::{aliases::*, Fdflags, Filetype, Status};
+use super::{aliases::*, Clockid, Fdflags, Filetype, Status};
 
 #[derive(Copy, Clone)]
 #[repr(C)]


### PR DESCRIPTION
This implements `clock_res_get` and `clock_time_get` apis for wasi.

Implementation is based on wasmer.

There are two new dependencies:
 - libc => adds functionality for unix
 - winapi => adds functionality for windows

There are some unimplemented methods for windows platform (same is with wasmer) which I didn't go deep into atm but basic clock should work. Error handling can be a bit better for unix implementation and there are some TODOs for that.

Build passes for both `x86_64-pc-windows-gnu` and default linux target.