### PR TITLE
Add simple heap profiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "libc",
  "log",
  "pretty_assertions",
+ "rand",
  "rayon",
  "smallvec",
  "smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ rayon = "1.5"
 wat = "1.0"
 wasmprinter = "0.2"
 pretty_assertions = "0.6.1"
+rand = "0.8"
 
 [[bench]]
 name = "lunatic_benchmark"

--- a/src/api/channel/api.rs
+++ b/src/api/channel/api.rs
@@ -21,7 +21,7 @@ pub struct ChannelState {
 
 /// Host resources need to be sent separately to another instance, because they can't be serialized on
 /// the guest. This is done by adding them to `next_message_host_resources` during the serialization
-/// ont the guest and just serializing it as the index of the resource in this array.
+/// on the guest and just serializing it as the index of the resource in this array.
 ///
 /// Smol's channels don't allow you to peek into the message without consuming it, but Lunatic's API
 /// requires us to check the size of the next message, so that the guest side can allocate a big enough

--- a/src/api/default.rs
+++ b/src/api/default.rs
@@ -9,25 +9,31 @@ pub struct DefaultApi {
     context_receiver: Option<ChannelReceiver>,
     module: LunaticModule,
     profiler: <heap_profiler::HeapProfilerState as HostFunctions>::Wrap,
+    wasi: <wasi::state::WasiState as HostFunctions>::Wrap,
 }
 
 impl DefaultApi {
     pub fn new(context_receiver: Option<ChannelReceiver>, module: LunaticModule) -> Self {
         let (_, profiler) = heap_profiler::HeapProfilerState::new().split();
+        let (_, wasi) = wasi::state::WasiState::new().split();
         Self {
             context_receiver,
             module,
             profiler,
+            wasi,
         }
     }
 }
 
 impl HostFunctions for DefaultApi {
-    type Return = <heap_profiler::HeapProfilerState as HostFunctions>::Wrap;
+    type Return = (
+        <heap_profiler::HeapProfilerState as HostFunctions>::Wrap,
+        <wasi::state::WasiState as HostFunctions>::Wrap,
+    );
     type Wrap = Self;
 
     fn split(self) -> (Self::Return, Self::Wrap) {
-        (self.profiler.clone(), self)
+        ((self.profiler.clone(), self.wasi.clone()), self)
     }
 
     fn add_to_linker<E>(api: Self, executor: E, linker: &mut wasmtime::Linker)
@@ -50,10 +56,8 @@ impl HostFunctions for DefaultApi {
         let (_, networking_state) = networking_state.split();
         networking::TcpState::add_to_linker(networking_state, executor.clone(), linker);
 
-        let wasi_state = wasi::state::WasiState::new();
-        let (_, wasi_state) = wasi_state.split();
-        wasi::state::WasiState::add_to_linker(wasi_state, executor.clone(), linker);
+        heap_profiler::HeapProfilerState::add_to_linker(api.profiler, executor.clone(), linker);
 
-        heap_profiler::HeapProfilerState::add_to_linker(api.profiler, executor, linker);
+        wasi::state::WasiState::add_to_linker(api.wasi, executor.clone(), linker);
     }
 }

--- a/src/api/heap_profiler.rs
+++ b/src/api/heap_profiler.rs
@@ -1,0 +1,142 @@
+use std::collections::{HashMap, VecDeque};
+use std::fs::File;
+use std::io::Write;
+use std::time::{Duration, SystemTime};
+use uptown_funk::host_functions;
+
+use log::debug;
+use log::error;
+
+type Ptr = u32;
+type Size = u32;
+const HISTORY_CAPACITY: usize = 100_000;
+
+pub struct HeapProfilerState {
+    memory: HashMap<Ptr, Size>,
+    started: SystemTime,
+    heap_history: VecDeque<(i32, Duration)>,
+}
+
+impl HeapProfilerState {
+    pub fn new() -> Self {
+        Self {
+            memory: HashMap::new(),
+            started: SystemTime::now(),
+            heap_history: VecDeque::new(),
+        }
+    }
+
+    // Merge child process profile results into parent process.
+    //
+    // Usually this should be called when child process exits.
+    pub fn merge(&mut self, profiler: HeapProfilerState) {
+        self.started = std::cmp::min(self.started, profiler.started);
+        let started_delta = profiler.started.duration_since(self.started).unwrap();
+        // TODO sorted state merging of two sorted lists can be done in O(N+M)
+        // currently this runs in O((N+M)*log(N+M)*C)
+        profiler.heap_history.iter().for_each(|(h, d)| {
+            self.heap_history.push_back((*h, *d + started_delta));
+        });
+        self.heap_history
+            .make_contiguous()
+            .sort_unstable_by_key(|&(_, d)| d);
+        // remove oldest extra elements (ringbuffer)
+        if self.heap_history.len() > HISTORY_CAPACITY {
+            self.heap_history
+                .drain(0..(self.heap_history.len() - HISTORY_CAPACITY));
+        }
+    }
+
+    // Deallocate remaining memory. This is invoked when process exits
+    pub fn free_all(&mut self) {
+        // implicitly deallocate all left over child memory
+        self.memory.clone().iter().for_each(|(k, _)| {
+            self.free_profiler(*k);
+        });
+    }
+
+    // Write heap profile history to a file. Format:
+    //
+    // #time/sec heap/byte
+    // 0.1       10
+    // 0.2       15
+    // ...
+    pub fn write_dat(&self, fd: &mut File) -> std::io::Result<()> {
+        let mut graph = Vec::new();
+        let mut heap_size: u64 = 0;
+        writeln!(&mut graph, "#time/sec heap/byte")?;
+        // write initial entry for plotting
+        writeln!(&mut graph, "0 0").unwrap();
+        self.heap_history.iter().for_each(|(heap, duration)| {
+            if *heap < 0 {
+                // TODO check for overflow
+                heap_size -= (-*heap) as u64;
+            } else {
+                heap_size += *heap as u64;
+            }
+            writeln!(&mut graph, "{} {}", duration.as_secs_f64(), heap_size).unwrap();
+        });
+        fd.write_all(&graph)
+    }
+
+    fn history_push(&mut self, change: i32) {
+        if self.heap_history.len() == HISTORY_CAPACITY {
+            // if HISTRY_CAPACITY > 0 this should be safe
+            self.heap_history.pop_front().unwrap();
+        }
+        // TODO: trap/log error if elapsed failed
+        // very unlikely to happen!
+        self.heap_history
+            .push_back((change, self.started.elapsed().unwrap()));
+    }
+}
+
+#[host_functions(namespace = "heap_profiler")]
+impl HeapProfilerState {
+    fn aligned_alloc_profiler(&mut self, _self: u32, size: Size, ptr: Ptr) {
+        self.malloc_profiler(size, ptr);
+    }
+
+    fn malloc_profiler(&mut self, size: Size, ptr: Ptr) {
+        debug!("heap_profiler: malloc({}) -> {}", size, ptr);
+        self.memory.insert(ptr, size);
+        self.history_push(size as i32);
+    }
+
+    fn calloc_profiler(&mut self, len: Size, elem_size: Size, ptr: Ptr) {
+        debug!("heap_profiler: calloc({},{}) -> {}", len, elem_size, ptr);
+        let size = len * elem_size;
+        self.memory.insert(ptr, size);
+        self.history_push(size as i32);
+    }
+
+    fn realloc_profiler(&mut self, old_ptr: Ptr, size: Size, new_ptr: Ptr) {
+        debug!(
+            "heap_profiler: realloc({},{}) -> {}",
+            old_ptr, size, new_ptr
+        );
+        match self.memory.remove(&old_ptr) {
+            Some(removed_size) => {
+                self.memory.insert(new_ptr, size);
+                let size_delta = size as i32 - removed_size as i32;
+                self.history_push(size_delta);
+            }
+            None => error!(
+                "heap_profiler: can't reallocate, pointer {} doesn't exist",
+                old_ptr
+            ),
+        };
+    }
+
+    fn free_profiler(&mut self, ptr: Ptr) {
+        debug!("heap_profiler: free({})", ptr);
+        if ptr != 0 {
+            match self.memory.remove(&ptr) {
+                Some(size) => {
+                    self.history_push(-(size as i32));
+                }
+                None => error!("heap_profiler: can't free, pointer {} doesn't exist", ptr),
+            };
+        }
+    }
+}

--- a/src/api/heap_profiler.rs
+++ b/src/api/heap_profiler.rs
@@ -91,7 +91,7 @@ impl HeapProfilerState {
     }
 }
 
-#[host_functions(namespace = "heap_profiler")]
+#[host_functions(namespace = "heap_profiler", sync = "mutex")]
 impl HeapProfilerState {
     fn aligned_alloc_profiler(&mut self, _self: u32, size: Size, ptr: Ptr) {
         self.malloc_profiler(size, ptr);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod channel;
 pub mod default;
+pub mod heap_profiler;
 pub mod networking;
 pub mod process;
 pub mod wasi;

--- a/src/api/process/process.rs
+++ b/src/api/process/process.rs
@@ -135,7 +135,7 @@ impl Process {
         memory: MemoryChoice,
     ) -> Result<HeapProfilerState> {
         let api = crate::api::default::DefaultApi::new(context_receiver, module.clone());
-        let (profiler, fut) = Process::create_with_api(module, function, memory, api)?;
+        let ((profiler, _), fut) = Process::create_with_api(module, function, memory, api)?;
         fut.await?;
 
         // NOTE it should be safe to unwrap here

--- a/src/api/wasi/api.rs
+++ b/src/api/wasi/api.rs
@@ -25,7 +25,7 @@ use super::unix::*;
 #[cfg(any(target_os = "windows"))]
 use super::windows::*;
 
-#[host_functions(namespace = "wasi_snapshot_preview1")]
+#[host_functions(namespace = "wasi_snapshot_preview1", sync = "mutex")]
 impl WasiState {
     // Command line arguments and environment variables
 

--- a/src/api/wasi/api.rs
+++ b/src/api/wasi/api.rs
@@ -25,7 +25,7 @@ use super::unix::*;
 #[cfg(any(target_os = "windows"))]
 use super::windows::*;
 
-#[host_functions(namespace = "wasi_snapshot_preview1", sync = "mutex")]
+#[host_functions(namespace = "wasi_snapshot_preview1")]
 impl WasiState {
     // Command line arguments and environment variables
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ pub fn run() -> Result<()> {
     let cpus = thread::available_concurrency().unwrap();
     let (signal, shutdown) = smol::channel::unbounded::<()>();
 
-    Parallel::new()
+    let profiler = Parallel::new()
         .each(0..cpus.into(), |_| {
             smol::future::block_on(EXECUTOR.run(shutdown.recv()))
         })
@@ -60,6 +60,11 @@ pub fn run() -> Result<()> {
             })
         })
         .1?;
+    if is_profile {
+        let mut profile_out = std::fs::File::create("heap.dat")?;
+        profiler.write_dat(&mut profile_out)?;
+    }
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,14 +21,22 @@ struct Opts {
     /// All other arguments are forwarded to the .wasm file
     #[clap(min_values(0))]
     _args: Vec<String>,
+    /// Save heap profile to heap.dat
+    #[clap(short, long)]
+    profile: bool,
+    /// Output patched/normalised wasm to normalised.wasm
+    #[clap(short, long)]
+    normalised_out: bool,
 }
 
 pub fn run() -> Result<()> {
     let opts: Opts = Opts::parse();
+    let is_profile = opts.profile;
 
     let wasm = fs::read(opts.input).expect("Can't open .wasm file");
 
-    let module = module::LunaticModule::new(&wasm, Runtime::default())?;
+    let module =
+        module::LunaticModule::new(&wasm, Runtime::default(), is_profile, opts.normalised_out)?;
 
     // Set up async runtime
     let cpus = thread::available_concurrency().unwrap();

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -44,9 +44,14 @@ pub struct LunaticModule {
 }
 
 impl LunaticModule {
-    pub fn new(wasm: &[u8], runtime: Runtime) -> Result<Self> {
+    pub fn new(
+        wasm: &[u8],
+        runtime: Runtime,
+        is_profile: bool,
+        is_normalisation_out: bool,
+    ) -> Result<Self> {
         // Transfrom WASM file into a format compatible with Lunatic.
-        let ((min_memory, max_memory), wasm) = patch(&wasm)?;
+        let ((min_memory, max_memory), wasm) = patch(&wasm, is_profile, is_normalisation_out)?;
 
         let module = match runtime {
             Runtime::Wasmtime => Module::Wasmtime(WasmtimeModule::new(&wasmtime_engine(), wasm)?),

--- a/src/module/normalisation/heap_profiler.rs
+++ b/src/module/normalisation/heap_profiler.rs
@@ -1,0 +1,219 @@
+use log::error;
+use std::collections::HashMap;
+use walrus::*;
+
+/// Modifies the WASM binary to add heap profiling support. Every time one of allocation function
+/// is called:
+///  * malloc(arg1) -> ret
+///  * aligned_alloc(arg1, arg2) -> ret
+///  * calloc(arg1, arg2) -> ret
+///  * realloc(arg1, arg2) -> ret
+///  * free(arg1)
+/// extra call to its profiling function will be invoked:
+///  * malloc_profiler(arg1, ret)
+///  * aligned_alloc_profiler(arg1, arg2, ret)
+///  * calloc_profiler(arg1, arg2, ret)
+///  * realloc_profiler(arg1, arg2, ret)
+///  * free_profiler(arg1)
+///
+/// Profiling functions are imported from heap_profiler module.
+///
+/// Functions that can't be found in a module are ignored and error is logged.
+pub fn patch(module: &mut Module) {
+    // NOTE rusts global allocator __rust_alloc sometimes will
+    // execute aligned_alloc instead of malloc
+    ["malloc", "aligned_alloc", "calloc", "realloc", "free"]
+        .iter()
+        .for_each(|name| {
+            add_profiler_to(module, name).unwrap_or_else(|e| error!("{}", e));
+        });
+}
+
+// This function adds profiling capabilities to a local function with
+// provided name. If function with such name exists this function will:
+//   * add an import statement that imports "{name}_profiler"
+//   * move all instructions to a new function called "{name}_wrap"
+//   * invoke "{name}_wrap" function and "{name}_profiler" from original function
+//
+//   In essence it will convert (pseudo code):
+//
+//   (func $name ...
+//     ...
+//   )
+//
+//   Into:
+//
+//   (import "name_profiler")
+//
+//   (func $name ...
+//     call $name_wrap
+//     call $name_profiler
+//   )
+//   (func $name_wrap ...
+//     ...
+//   )
+//
+// "{name}_profiler function has the same arguments as "name" function with one
+// optional last argument. This last argument is a return value from "name"
+// function if such exists.
+fn add_profiler_to(module: &mut Module, name: &str) -> Result<()> {
+    // find local function in module
+    let fn_id = module
+        .funcs
+        .by_name(name)
+        .ok_or(anyhow::Error::msg(format!(
+            "heap_profiler: '{}' was not found in wasm",
+            name
+        )))?;
+    let types = module.types.params_results(module.funcs.get(fn_id).ty());
+    let (params, results) = (types.0.to_vec(), types.1.to_vec());
+
+    // Import profiler. Profilers don't return anything. Profilers last argument
+    // is result from the original function. For example, local function "malloc(i32) -> u32"
+    // will import profiler of type "malloc(i32, u32)".
+    let profiler_type = module
+        .types
+        .add(&[params.clone(), results.clone()].concat(), &[]);
+    let profiler_id = module
+        .add_import_func(
+            "heap_profiler",
+            &format!("{}_profiler", name),
+            profiler_type,
+        )
+        .0;
+
+    // create a clone of a function
+    let fn_copy_id = clone_function(module, fn_id, Some(format!("{}_wrap", name)));
+
+    let locals = &mut module.locals;
+    // create new local params for wrapper function, old params are copied (see clone above) to new
+    // function
+    let local_vars: Vec<LocalId> = params.iter().map(|t| locals.add(*t)).collect();
+    let rets: Vec<LocalId> = results.iter().map(|t| locals.add(*t)).collect();
+    let mut instr_seq = module
+        .funcs
+        .get_mut(fn_id)
+        .kind
+        .unwrap_local_mut()
+        .builder_mut()
+        .func_body();
+
+    // remove all instructions from wrapper function (they are copied over to new function)
+    *instr_seq.instrs_mut() = vec![];
+
+    // prepare args to call new function
+    local_vars.iter().for_each(|l| {
+        instr_seq.local_get(*l);
+    });
+
+    // call new copied function from wrapper function
+    instr_seq.call(fn_copy_id);
+
+    // save returned values from the above function
+    rets.iter().for_each(|r| {
+        instr_seq.local_set(*r);
+    });
+
+    // prepare args to call profiler function
+    local_vars.iter().for_each(|l| {
+        instr_seq.local_get(*l);
+    });
+    rets.iter().for_each(|r| {
+        instr_seq.local_get(*r);
+    });
+
+    // call profiler function
+    instr_seq.call(profiler_id);
+
+    // return saved values from original function
+    rets.iter().for_each(|r| {
+        instr_seq.local_get(*r);
+    });
+
+    // modify wrapper function args
+    module.funcs.get_mut(fn_id).kind.unwrap_local_mut().args = local_vars;
+    Ok(())
+}
+
+// TODO: move to normalisation/utils.rs ?
+// Create a new local function that will have same signiture and same
+// instructions as the supplied local function.
+fn clone_function(module: &mut Module, fn_id: FunctionId, name: Option<String>) -> FunctionId {
+    let types = module.types.params_results(module.funcs.get(fn_id).ty());
+    let (params, results) = (types.0.to_vec(), types.1.to_vec());
+
+    let mut fn_builder = FunctionBuilder::new(&mut module.types, &params, &results);
+    let fn_local_function = module.funcs.get(fn_id).kind.unwrap_local();
+    if let Some(name) = name {
+        fn_builder.name(name);
+    }
+    let mut fn_instr_seq = fn_builder.func_body();
+
+    // copy instructions from fn_id to new function
+    clone_rec(
+        fn_local_function,
+        fn_local_function.block(fn_local_function.entry_block()),
+        &mut fn_instr_seq,
+        &mut HashMap::new(),
+    );
+    let fn_copy_id = fn_builder.finish(fn_local_function.args.clone(), &mut module.funcs);
+
+    // number of instructions in original and cloned function should match
+    assert_eq!(
+        module.funcs.get(fn_id).kind.unwrap_local().size(),
+        module.funcs.get(fn_copy_id).kind.unwrap_local().size()
+    );
+    fn_copy_id
+}
+
+// Recursively clone instructions from a local function.
+fn clone_rec(
+    fn_loc: &LocalFunction,
+    instrs: &ir::InstrSeq,
+    instrs_clone: &mut InstrSeqBuilder,
+    // TODO use Rc<RefCell<HashMap<..>>> to avoid cloning in ifElse block
+    jmp_ids: &mut HashMap<ir::InstrSeqId, ir::InstrSeqId>,
+) {
+    jmp_ids.insert(instrs.id(), instrs_clone.id());
+    instrs.instrs.iter().for_each(|(i, _)| match i {
+        ir::Instr::Block(block) => {
+            let block_instrs = fn_loc.block(block.seq);
+            instrs_clone.block(block_instrs.ty, |block_clone| {
+                clone_rec(fn_loc, block_instrs, block_clone, jmp_ids);
+            });
+        }
+        ir::Instr::IfElse(if_else) => {
+            let consequent_instrs = fn_loc.block(if_else.consequent);
+            let jmp_ids_clone = &mut jmp_ids.clone();
+            instrs_clone.if_else(
+                consequent_instrs.ty,
+                |consequent_clone| {
+                    clone_rec(fn_loc, consequent_instrs, consequent_clone, jmp_ids);
+                },
+                |alternative_clone| {
+                    clone_rec(
+                        fn_loc,
+                        fn_loc.block(if_else.alternative),
+                        alternative_clone,
+                        jmp_ids_clone,
+                    );
+                },
+            );
+        }
+        ir::Instr::Loop(loop_) => {
+            let loop_instrs = fn_loc.block(loop_.seq);
+            instrs_clone.loop_(loop_instrs.ty, |loop_clone| {
+                clone_rec(fn_loc, loop_instrs, loop_clone, jmp_ids);
+            });
+        }
+        ir::Instr::Br(br) => {
+            instrs_clone.br(jmp_ids[&br.block]);
+        }
+        ir::Instr::BrIf(br_if) => {
+            instrs_clone.br_if(jmp_ids[&br_if.block]);
+        }
+        _ => {
+            instrs_clone.instr(i.clone());
+        }
+    });
+}

--- a/tests/normalisation_patching_test.rs
+++ b/tests/normalisation_patching_test.rs
@@ -33,6 +33,7 @@ fn find_tests(path: &Path, tests: &mut Vec<PathBuf>) {
 
 fn run_tests(tests: Vec<PathBuf>) {
     for test in tests {
+        println!("Running test: {}", test.to_str().unwrap());
         let test_content = read_to_string(&test).unwrap();
         let input_expected_output: Vec<_> = test_content.split("EXPECTED-RESULT:").collect();
         let input = input_expected_output.first().unwrap();
@@ -52,10 +53,11 @@ fn run_tests(tests: Vec<PathBuf>) {
         let output_multiline: Vec<&str> = output_wat.split("\n").into_iter().collect();
 
         assert_eq!(expected_output_multiline, output_multiline);
+        println!("Test OK!");
     }
 }
 
 fn run_test(input: &str) -> Vec<u8> {
     let wasm = wat::parse_str(input).unwrap();
-    patch(&wasm).unwrap().1
+    patch(&wasm, true, false).unwrap().1
 }

--- a/tests/normalisation_patching_test/block_heap_profiler.wat
+++ b/tests/normalisation_patching_test/block_heap_profiler.wat
@@ -1,0 +1,101 @@
+;; NOTE expected result is long due too reduction counter logic
+;; Input
+(module
+    (type (;0;) (func))
+    (type (;1;) (func (param i32) (result i32)))
+    (type (;2;) (func (param i32 i32)))
+    (func $malloc (type 1) (param i32) (result i32)
+        block ;; test block
+            i32.const 0
+            block ;; test nested block
+                i32.const 0
+                i32.eqz
+                if ;; test if block
+                    i32.const 0
+                    drop
+                else
+                    br 0 ;; test br statement
+                end
+                loop ;; test loop block
+                    i32.const 0
+                    i32.eqz
+                    br_if 2 ;; test br if statement
+                end
+            end
+            drop
+        end
+        i32.const 0
+    )
+)
+
+;; EXPECTED-RESULT:
+(module
+    (type (;0;) (func))
+    (type (;1;) (func (param i32) (result i32)))
+    (type (;2;) (func (param i32 i32)))
+    (import "lunatic" "yield_" (func (;0;) (type 0)))
+    (import "heap_profiler" "malloc_profiler" (func (;1;) (type 2)))
+    (func $malloc_wrap (type 1) (param i32) (result i32)
+        block  ;; Reduction counter logic
+            global.get 0
+            i32.const 1
+            i32.add
+            global.set 0
+            global.get 0
+            i32.const 10000
+            i32.gt_s
+            if
+                call 0
+                i32.const 0
+                global.set 0
+            else
+            end
+        end
+        block ;; test block
+            i32.const 0
+            block ;; test nested block
+                i32.const 0
+                i32.eqz
+                if ;; test if block
+                    i32.const 0
+                    drop
+                else
+                    br 0 ;; test jmp statement
+                end
+                loop ;; test loop block
+                    block  ;; Reduction counter logic
+                        global.get 0
+                        i32.const 1
+                        i32.add
+                        global.set 0
+                        global.get 0
+                        i32.const 10000
+                        i32.gt_s
+                        if
+                            call 0
+                            i32.const 0
+                            global.set 0
+                        else
+                        end
+                    end
+                    i32.const 0
+                    i32.eqz
+                    br_if 2 ;; test jmp if statement
+                end
+            end
+            drop
+        end
+        i32.const 0
+    )
+    (func $malloc (type 1) (param i32) (result i32)
+          (local i32)
+          local.get 0
+          call $malloc_wrap
+          local.set 1
+          local.get 0
+          local.get 1
+          call 1
+          local.get 1
+    )
+    (global (;0;) (mut i32) (i32.const 0))
+)

--- a/tests/normalisation_patching_test/simple_heap_profiler.wat
+++ b/tests/normalisation_patching_test/simple_heap_profiler.wat
@@ -1,0 +1,182 @@
+;; NOTE expected result is long due too reduction counter logic
+;; Input
+(module
+    (type (;0;) (func))
+    (type (;1;) (func (param i32)))
+    (type (;2;) (func (param i32) (result i32)))
+    (type (;3;) (func (param i32 i32)))
+    (type (;4;) (func (param i32 i32) (result i32)))
+    (type (;5;) (func (param i32 i32 i32)))
+    (func $malloc (type 2) (param i32) (result i32)
+        i32.const 0
+    )
+    (func $aligned_alloc (type 4) (param i32 i32) (result i32)
+        i32.const 0
+    )
+    (func $calloc (type 4) (param i32 i32) (result i32)
+        i32.const 0
+    )
+    (func $realloc (type 4) (param i32 i32) (result i32)
+        i32.const 0
+    )
+    (func $free (type 1) (param i32)
+    )
+)
+
+;; EXPECTED-RESULT:
+(module
+    (type (;0;) (func))
+    (type (;1;) (func (param i32)))
+    (type (;2;) (func (param i32) (result i32)))
+    (type (;3;) (func (param i32 i32)))
+    (type (;4;) (func (param i32 i32) (result i32)))
+    (type (;5;) (func (param i32 i32 i32)))
+    (import "lunatic" "yield_" (func (;0;) (type 0)))
+    (import "heap_profiler" "malloc_profiler" (func (;1;) (type 3)))
+    (import "heap_profiler" "aligned_alloc_profiler" (func (;2;) (type 5)))
+    (import "heap_profiler" "calloc_profiler" (func (;3;) (type 5)))
+    (import "heap_profiler" "realloc_profiler" (func (;4;) (type 5)))
+    (import "heap_profiler" "free_profiler" (func (;5;) (type 1)))
+    (func $malloc_wrap (type 2) (param i32) (result i32)
+        block  ;; Reduction counter logic
+            global.get 0
+            i32.const 1
+            i32.add
+            global.set 0
+            global.get 0
+            i32.const 10000
+            i32.gt_s
+            if
+                call 0
+                i32.const 0
+                global.set 0
+            else
+            end
+        end
+        i32.const 0
+    )
+    (func $aligned_alloc_wrap (type 4) (param i32 i32) (result i32)
+        block  ;; Reduction counter logic
+            global.get 0
+            i32.const 1
+            i32.add
+            global.set 0
+            global.get 0
+            i32.const 10000
+            i32.gt_s
+            if
+                call 0
+                i32.const 0
+                global.set 0
+            else
+            end
+        end
+        i32.const 0
+    )
+    (func $calloc_wrap (type 4) (param i32 i32) (result i32)
+        block  ;; Reduction counter logic
+            global.get 0
+            i32.const 1
+            i32.add
+            global.set 0
+            global.get 0
+            i32.const 10000
+            i32.gt_s
+            if
+                call 0
+                i32.const 0
+                global.set 0
+            else
+            end
+        end
+        i32.const 0
+    )
+    (func $realloc_wrap (type 4) (param i32 i32) (result i32)
+        block  ;; Reduction counter logic
+            global.get 0
+            i32.const 1
+            i32.add
+            global.set 0
+            global.get 0
+            i32.const 10000
+            i32.gt_s
+            if
+                call 0
+                i32.const 0
+                global.set 0
+            else
+            end
+        end
+        i32.const 0
+    )
+    (func $free_wrap (type 1) (param i32)
+        block  ;; Reduction counter logic
+            global.get 0
+            i32.const 1
+            i32.add
+            global.set 0
+            global.get 0
+            i32.const 10000
+            i32.gt_s
+            if
+                call 0
+                i32.const 0
+                global.set 0
+            else
+            end
+        end
+    )
+    (func $aligned_alloc (type 4) (param i32 i32) (result i32)
+          (local i32)
+          local.get 0
+          local.get 1
+          call $aligned_alloc_wrap
+          local.set 2
+          local.get 0
+          local.get 1
+          local.get 2
+          call 2
+          local.get 2
+    )
+    (func $calloc (type 4) (param i32 i32) (result i32)
+          (local i32)
+          local.get 0
+          local.get 1
+          call $calloc_wrap
+          local.set 2
+          local.get 0
+          local.get 1
+          local.get 2
+          call 3
+          local.get 2
+    )
+    (func $realloc (type 4) (param i32 i32) (result i32)
+          (local i32)
+          local.get 0
+          local.get 1
+          call $realloc_wrap
+          local.set 2
+          local.get 0
+          local.get 1
+          local.get 2
+          call 4
+          local.get 2
+    )
+    (func $malloc (type 2) (param i32) (result i32)
+          (local i32)
+          local.get 0
+          call $malloc_wrap
+          local.set 1
+          local.get 0
+          local.get 1
+          call 1
+          local.get 1
+    )
+    (func $free (type 1) (param i32)
+          local.get 0
+          call $free_wrap
+          local.get 0
+          call 5
+    )
+    (global (;0;) (mut i32) (i32.const 0))
+)


### PR DESCRIPTION
# Abstract

This PR adds support for simple heap profiler. If flag `-p` is given, lunatic will output `heap.dat` file that contains profile data (time/heap data points). If more subprocesses are run within profiled process then profile will contain merged data points of master process with child processes.

Tested languages: C, Rust

# Details

Every child process will create its own `HeapProfilerState`. This object tracks history of all invocations of `malloc`, `calloc`, `realloc`, `free`, `aligned_alloc`. History for every process is tracked in ringbuffer (max ~3mb). When child process terminates, his history is merged with parent process history. When parent process terminates, history is written to `heap.dat` file. 

# Caveat

Merging of histories is done in `O((N+M)*log(N+M))` where `N` is parent process history and `M` is child process history and its using `N+M` extra temporary memory. This is to properly implement ringbuffer (older elements get dropped). In practice this means that if we are profiling and child process terminates we are going to temporary alocate ~5mb (2* history buffer) and spend some time to rearange ringbuffer. Benefit is that profiling of long running processes (with many spawned child processes) will be realativelly cheap. At any point in time profiling will be expensive as `N`*`history`, where `N` is processes currently running and `history` buffer with maximum size of ~3mb. History buffer size can be configured.

With little effort (20 loc) the above can be optimized to use `O(N+M)` but atm I don't think its worth the effort (as code becomes less maintainable). There is an extra TODO in code when this would be needed

Objective when designing solution for this feature was that profiling will be used in lunatic cli for development/debugging of guest programs; not in production so simple design/implementation was prefered.

# Alternatives

There are few alternative solutions explored:
 1) defer history merging after master process exists
      - instead of merging immediatelly when child process exists, we could carry all childs heap buffers until master process finishes and then merge.
   * Pros:
        - merging is done after master process terminates so doesn't effect process performance
   * Cons:
        - higher memory footprint for multiprocess apps (because all history buffers are held until master process exits and not merged/cleaned immediatelly)
        
 2) all subprocesses share same `HeapProfilerState`.
   * Pros:
        - low profiling memory overhead (only one history ringbuffer); <3mb memory
        - no merging histories in multiprocess application (no time penalty for merging)
        - enables live profiling (we could observe profiler while program is executing)
   * Cons:
        - time penalty for mutex syncing in multiprocess heavy aplications (ie. only one process at a time can call `malloc`)
        - more complicated tracking of proces pid-s
            * this is due to a bug where `free` is not called for all resources when process is finished. To workaround, we have to manually call `free` for resources traced by some process. This is easy if every process has its own `HeapProfilerState` (as implemented in this PR), but gets trickier if all processes share same `HeapProfilerState`. Then every process should actually call `free(pid, ptr)`, where `pid` is extra argument carying process id. Or `HeapProfilerState` should have access to current process id somehow. This involves extra hacking
        
Also note that in current implementation `HeapProfilerState` is passed from child to parrent process by process return value (in host): https://github.com/lunatic-solutions/lunatic/compare/heap_profiler?expand=1#diff-89815f1e2909a7ef216763b9b930a308e2b718bf17ebfc270433d4abde0635f5R46 . Initially I wasn't happy about this, but actually it makes perfect sense and intention is clear in the source code. Alternitively this state passing from child process to parrent process can be hidden (handled by a mutex/ref passed through all processes) but for this use cases I prefer it as it is done in this PR.

# Extra

Additional flag `-n` is added for easier debugging. This flag will output file `normalisation.wasm` that contains patched/normalised input file.

# Todo

 * There are some TODO's left in comments.
 * normalisation tests could be made simpler
     - tests are run after all patches are applied so reduction counter logic/patch makes heap profiler tests unnecessary verbose. We could refactor `tests/normalisation_patching_test.rs` so that it runs tests for specific patch only. For example reduction counter tests would test only reduction counter patch, and heap profiler tests would test only heap profiler patch. Atm this isn't the case and every test is testing all patches. This has its cons and pros