### PR TITLE
Setup env when spawning new process

### DIFF
--- a/src/module/normalisation/stdlib.rs
+++ b/src/module/normalisation/stdlib.rs
@@ -16,7 +16,7 @@ pub fn patch(module: &mut Module) -> Result<()> {
                 builder.func_body().call(ctors);
             }
             // ignore if __wasm_call_ctors wasn't found
-            None => log::error!("__wasm_call_ctors wasn't found."),
+            None => log::info!("__wasm_call_ctors wasn't found."),
         };
         builder
             .func_body()

--- a/src/module/normalisation/stdlib.rs
+++ b/src/module/normalisation/stdlib.rs
@@ -9,6 +9,15 @@ pub fn patch(module: &mut Module) -> Result<()> {
         let lunatic_spawn_by_index_type = module.types.add(&[], &[]);
         // Create the index parameter
         let index = module.locals.add(ValType::I32);
+        // invoke __wasm_call_ctors to properly setup environment
+        // FIXME remove this when wasm adds proper environment initialisation
+        match module.funcs.by_name("__wasm_call_ctors") {
+            Some(ctors) => {
+                builder.func_body().call(ctors);
+            }
+            // ignore if __wasm_call_ctors wasn't found
+            None => log::error!("__wasm_call_ctors wasn't found."),
+        };
         builder
             .func_body()
             .local_get(index)


### PR DESCRIPTION
This PR explicitly setups environment for spawned processes. It will try to call `__wasm_call_ctors` before calling spawned process. `__wasm_call_ctors` currently:
 * setups environment vars (stores env vars to linear memory)
 * registers preopened file descriptors
 
When `__wasm_call_ctors` symbol isn't found guest aplication will continue to run as before this PR (error will be logged but it won't fail to run); this makes more programs run correctly but it doesn't break others.

# How to reproduce
This example doesn't work before this patch on linux:
```
use lunatic::Process;

fn main() {
    Process::spawn_with((), |_: ()| {
        println!("{}", std::env::var("HOME").unwrap());
    })
    .join()
    .unwrap();
}
```
Also, any other function from `std::` that work with file descriptors like `File::open` wouldn't work as file descriptors weren't registered.