### PR TITLE
Enable heap profile observing while process is running

### DIFF
--- a/src/api/heap_profiler.rs
+++ b/src/api/heap_profiler.rs
@@ -221,22 +221,26 @@ fn merge_profiles() {
         memory: random_memory(),
         started: std::time::UNIX_EPOCH + Duration::from_millis(rand::random()),
         heap_history: random_history(),
+        processes: vec![],
     };
     let child = HeapProfilerState {
         memory: random_memory(),
         // we assume child is started after parent process
         started: parent.started + Duration::from_millis(rand::random()),
         heap_history: random_history(),
+        processes: vec![],
     };
     let mut parent_clone = HeapProfilerState {
         memory: parent.memory.clone(),
         started: parent.started.clone(),
         heap_history: parent.heap_history.clone(),
+        processes: vec![],
     };
     let child_clone = HeapProfilerState {
         memory: child.memory.clone(),
         started: child.started.clone(),
         heap_history: child.heap_history.clone(),
+        processes: vec![],
     };
     fn merge_simple(parent: &mut HeapProfilerState, child: HeapProfilerState) {
         let started_delta = child.started.duration_since(parent.started).unwrap();

--- a/src/api/process/api.rs
+++ b/src/api/process/api.rs
@@ -70,6 +70,7 @@ impl ProcessState {
             self.module.clone(),
             FunctionLookup::TableIndex(index),
             MemoryChoice::New(None),
+            self.profiler.clone(),
         );
         Process::spawn(future)
     }
@@ -78,10 +79,7 @@ impl ProcessState {
     // Returns 0 if process didn't trap, otherwise 1
     async fn join(&self, process: Process) -> u32 {
         match process.task().await {
-            Ok(profiler) => {
-                self.profiler.lock().unwrap().merge(profiler);
-                0
-            }
+            Ok(_) => 0,
             Err(_) => 1,
         }
     }


### PR DESCRIPTION
This PR addresses:
 * revert process return type to () as host functions state will persist after a process halts 
     - https://github.com/lunatic-solutions/lunatic/pull/44#discussion_r626269812 
 * have observable state/profiler as the process is running
     - https://github.com/lunatic-solutions/lunatic/pull/44#discussion_r626264324
 
 `HeapProfilerState` now contains all process profile histories observable as the process is running. Merging of all process profile histories is done after master process is finished (as oposed to after every child process finishes which was behaviour before this PR) just before it is written to file system (in src/main.rs).
 
This implementation will keep profile history of every child process in memory until master process finishes. For long running applications which will need profiling we might need to add aditional heuristic to drop some of the history. For example, we might want to drop histories of processes of all processes that are finished, or we might want to drop some of older finished process histories. At the moment this is not the case and we keep all process histories (note that every process history has its ringbuffer)