### PR TITLE
Fixed the clock id match sections to match reference implementation

### DIFF
--- a/src/api/wasi/unix.rs
+++ b/src/api/wasi/unix.rs
@@ -19,9 +19,9 @@ fn errno_to_status(err: i32) -> Status {
 
 pub fn platform_clock_res_get(clock_id: Clockid, mut res: Pointer<Timestamp>) -> Status {
     let unix_clock_id = match clock_id {
-        Clockid::Realtime => CLOCK_MONOTONIC,
-        Clockid::Monotonic => CLOCK_PROCESS_CPUTIME_ID,
-        Clockid::ProcessCpuTimeId => CLOCK_REALTIME,
+        Clockid::Realtime => CLOCK_REALTIME,
+        Clockid::Monotonic => CLOCK_MONOTONIC,
+        Clockid::ProcessCpuTimeId => CLOCK_PROCESS_CPUTIME_ID,
         Clockid::ThreadCpuTimeId => CLOCK_THREAD_CPUTIME_ID,
         Clockid::Unsupported => return Status::Inval,
     };
@@ -46,9 +46,9 @@ pub fn platform_clock_time_get(
     mut time: Pointer<Timestamp>,
 ) -> StatusTrapResult {
     let unix_clock_id = match clock_id {
-        Clockid::Realtime => CLOCK_MONOTONIC,
-        Clockid::Monotonic => CLOCK_PROCESS_CPUTIME_ID,
-        Clockid::ProcessCpuTimeId => CLOCK_REALTIME,
+        Clockid::Realtime => CLOCK_REALTIME,
+        Clockid::Monotonic => CLOCK_MONOTONIC,
+        Clockid::ProcessCpuTimeId => CLOCK_PROCESS_CPUTIME_ID,
         Clockid::ThreadCpuTimeId => CLOCK_THREAD_CPUTIME_ID,
         Clockid::Unsupported => return Status::Inval.into(),
     };


### PR DESCRIPTION
Hi all,

After noticing issues with printing the correct time with chrono:
```rust
use chrono::prelude::*;

fn main () {
    println!("{}", Local::now());
}
```
This gave a time around 1970, so I went and found this inconsistency with the reference implementation.

[Reference implementation](https://github.com/wasmerio/wasmer/blob/0ab8a0de096ffdf89f353dd722a15b5e6255055f/lib/wasi/src/syscalls/unix/mod.rs)
```rust
let unix_clock_id = match clock_id {
    __WASI_CLOCK_MONOTONIC => CLOCK_MONOTONIC,
    __WASI_CLOCK_PROCESS_CPUTIME_ID => CLOCK_PROCESS_CPUTIME_ID,
    __WASI_CLOCK_REALTIME => CLOCK_REALTIME,
    __WASI_CLOCK_THREAD_CPUTIME_ID => CLOCK_THREAD_CPUTIME_ID,
    _ => return __WASI_EINVAL,
};
```