### PR TITLE
Add .wasm loading API for guests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli 0.24.0",
 ]
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "async-channel"
@@ -184,16 +184,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
+checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
 dependencies = [
- "addr2line 0.15.1",
+ "addr2line 0.15.2",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.24.0",
+ "object 0.25.2",
  "rustc-demangle",
 ]
 
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byteorder"
@@ -454,7 +454,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "log",
  "serde",
  "smallvec",
@@ -482,7 +482,7 @@ dependencies = [
  "clap 2.33.3",
  "criterion-plot",
  "csv",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -543,11 +543,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if",
  "lazy_static",
 ]
@@ -724,9 +723,9 @@ checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -801,9 +800,9 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -869,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -914,9 +913,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "5600b4e6efc5421841a2138a6b082e07fe12f9aaa12783d50e5d13325b26b4fc"
 
 [[package]]
 name = "log"
@@ -972,9 +971,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -1026,9 +1025,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
+checksum = "f8bc1d42047cf336f0f939c99e97183cf31551bf0f2865a2ec9c8d91fd4ffb5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -1220,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1315,12 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-dependencies = [
- "byteorder",
-]
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1476,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
+checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1486,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -1557,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/api/process/api.rs
+++ b/src/api/process/api.rs
@@ -1,12 +1,14 @@
 use crate::{
     api::channel::{api::ChannelState, ChannelReceiver, Message},
     api::heap_profiler,
-    module::LunaticModule,
+    module::{LunaticModule, Runtime},
 };
 
+use super::module_linking::{Import, Imports, ModuleResult};
 use super::{FunctionLookup, MemoryChoice, Process};
 
 use anyhow::Result;
+use log::error;
 use smol::{channel::bounded, future::yield_now, Timer};
 use uptown_funk::{host_functions, state::HashMapStore, HostFunctions};
 
@@ -19,6 +21,8 @@ pub struct ProcessState {
     module: LunaticModule,
     channel_state: ChannelState,
     pub processes: HashMapStore<Process>,
+    pub modules: HashMapStore<LunaticModule>,
+    pub imports: HashMapStore<Import>,
     profiler: <heap_profiler::HeapProfilerState as HostFunctions>::Wrap,
 }
 
@@ -32,6 +36,8 @@ impl ProcessState {
             module,
             channel_state,
             processes: HashMapStore::new(),
+            modules: HashMapStore::new(),
+            imports: HashMapStore::new(),
             profiler,
         }
     }
@@ -79,8 +85,11 @@ impl ProcessState {
     // Returns 0 if process didn't trap, otherwise 1
     async fn join(&self, process: Process) -> u32 {
         match process.task().await {
-            Ok(_) => 0,
-            Err(_) => 1,
+            Ok(()) => 0,
+            Err(err) => {
+                error!(target: "process", "Process trapped: {}", err);
+                1
+            }
         }
     }
 
@@ -98,5 +107,59 @@ impl ProcessState {
     // Detaches process
     async fn detach_process(&self, process: Process) {
         process.task().detach()
+    }
+
+    // Load a WASM buffer and create a module from it.
+    fn load_module(&self, wasm: &[u8]) -> (u32, ModuleResult) {
+        match LunaticModule::new(wasm, Runtime::default(), false, false) {
+            Ok(module) => (0, ModuleResult::Ok(module)),
+            Err(err) => {
+                error!(target: "process", "Module load error: {}", err);
+                (1, ModuleResult::Err)
+            }
+        }
+    }
+
+    fn unload_module(&mut self, id: u32) {
+        self.modules.remove(id);
+    }
+
+    // Define import from module
+    fn create_import(&self, name: &str, module: LunaticModule) -> Import {
+        Import(name.to_string(), module)
+    }
+
+    fn remove_import(&mut self, id: u32) {
+        self.imports.remove(id);
+    }
+
+    // Spawn a process from a module.
+    //
+    // imports - buffer of u32 indexes of imports used to satisfy instantiation.
+    fn spawn_from_module(
+        &self,
+        module: LunaticModule,
+        name: &str,
+        max_memory: u32,
+        imports: &[u8],
+    ) -> Process {
+        let imports: Vec<Option<Import>> = imports
+            .windows(4)
+            .map(|import| {
+                let mut import_exact = [0; 4];
+                import_exact.copy_from_slice(import); // Safe because window size is 4
+                let import_id = u32::from_le_bytes(import_exact);
+                self.imports.get(import_id).map(|x| x.clone())
+            })
+            .collect();
+        let imports = Imports::new(module.clone(), imports);
+        let (_, future) = Process::create_with_api(
+            module,
+            FunctionLookup::Name(String::from(name)),
+            MemoryChoice::New(Some(max_memory)),
+            imports,
+        )
+        .unwrap();
+        Process::spawn(future)
     }
 }

--- a/src/api/process/api.rs
+++ b/src/api/process/api.rs
@@ -94,11 +94,6 @@ impl ProcessState {
     }
 
     // Drops the Task and cancels the process
-    //
-    // It's currently not safe to cancel a process in Lunatic.
-    // All processes are executed on a separate stack, but if we cancel it the stack memory
-    // will be freed without actually unwinding it. This means that values and references
-    // living on the separate stack will never be freed.
     async fn cancel_process(&self, _process: Process) {
         // _process will take ownership here of the underlying task and drop it.
         // See: https://docs.rs/smol/latest/smol/struct.Task.html

--- a/src/api/process/env.rs
+++ b/src/api/process/env.rs
@@ -41,7 +41,7 @@ impl uptown_funk::Executor for ProcessEnvironment {
 // Because of a bug in Wasmtime: https://github.com/bytecodealliance/wasmtime/issues/2583
 // we need to duplicate the Memory in the Linker before storing it in ProcessEnvironment,
 // to not increase the reference count.
-// When we are droping the memory we need to make sure we forget the value to not decrease
+// When we are dropping the memory we need to make sure we forget the value to not decrease
 // the reference count.
 // Safety: The ProcessEnvironment has the same lifetime as Memory, so it should be safe to
 // do this.

--- a/src/api/process/mod.rs
+++ b/src/api/process/mod.rs
@@ -1,6 +1,7 @@
 pub mod api;
 mod env;
 mod err;
+mod module_linking;
 mod process;
 mod tls;
 

--- a/src/api/process/process.rs
+++ b/src/api/process/process.rs
@@ -27,7 +27,7 @@ lazy_static! {
 /// Used to look up a function by name or table index inside of an Instance.
 pub enum FunctionLookup {
     TableIndex(u32),
-    Name(&'static str),
+    Name(String),
 }
 
 /// For now we always create a new memory per instance, but eventually we will want to support
@@ -86,7 +86,7 @@ impl Process {
 
                     match function {
                         FunctionLookup::Name(name) => {
-                            let func = instance.get_func(name).ok_or_else(|| {
+                            let func = instance.get_func(&name).ok_or_else(|| {
                                 anyhow::Error::msg(format!(
                                     "No function {} in wasmtime instance",
                                     name

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ pub fn run() -> Result<()> {
                 let result = Process::create(
                     None,
                     module,
-                    FunctionLookup::Name("_start"),
+                    FunctionLookup::Name(String::from("_start")),
                     MemoryChoice::New(None),
                     profiler.clone(),
                 )

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -50,7 +50,7 @@ impl LunaticModule {
         is_profile: bool,
         is_normalisation_out: bool,
     ) -> Result<Self> {
-        // Transfrom WASM file into a format compatible with Lunatic.
+        // Transform WASM file into a format compatible with Lunatic.
         let ((min_memory, max_memory), wasm) = patch(&wasm, is_profile, is_normalisation_out)?;
 
         let module = match runtime {

--- a/src/module/normalisation/shared_memory.rs
+++ b/src/module/normalisation/shared_memory.rs
@@ -4,13 +4,21 @@ use walrus::*;
 /// Returns the initial and maximum memory sizes.
 pub fn patch(module: &mut Module) -> (u32, Option<u32>) {
     if let Some(memory) = module.memories.iter_mut().next() {
-        let memory_id = memory.id();
-        let memory_import = module
-            .imports
-            .add("lunatic", "memory", ImportKind::Memory(memory_id));
-        memory.shared = false;
-        memory.import = Some(memory_import);
-        (memory.initial, memory.maximum)
+        if let Some(_import) = memory.import {
+            // If existing memory is an imported one don't change it.
+            (memory.initial, memory.maximum)
+        } else {
+            // Create memory import
+            let memory_import =
+                module
+                    .imports
+                    .add("lunatic", "memory", ImportKind::Memory(memory.id()));
+            // Change existing memory to import
+            memory.shared = false;
+            memory.import = Some(memory_import);
+
+            (memory.initial, memory.maximum)
+        }
     } else {
         (0, None)
     }


### PR DESCRIPTION
This PR adds support for loading .wasm files directly from guest code and spawning processes from them.

To get a better feeling for the Rust API check out these tests:
https://github.com/lunatic-solutions/rust-lib/blob/main/tests/module_loading_test.rs

It also allows you to define modules that will be used as imports for other modules.
These imports can shadow the VM exported functions and behave as a proxy to VM exports.

At this moment the "import" modules are somewhat limited, as they don't have access to the child process memory. And the VM host functions will always reference the child processes memory and not the proxy one.