### PR TITLE
Add directories preopen

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub struct EnvConfig {
     // Maximum amount of compute expressed in units of 100k instructions.
     max_fuel: Option<u64>,
     allowed_namespaces: Vec<String>,
+    preopened_dirs: Vec<String>,
     plugins: Vec<Plugin>,
     wasi_args: Option<Vec<String>>,
     wasi_envs: Option<Vec<(String, String)>>,
@@ -22,6 +23,7 @@ impl EnvConfig {
             max_memory,
             max_fuel,
             allowed_namespaces: Vec::new(),
+            preopened_dirs: Vec::new(),
             plugins: Vec::new(),
             wasi_args: None,
             wasi_envs: None,
@@ -43,6 +45,15 @@ impl EnvConfig {
     /// Allow a WebAssembly host function namespace to be used with this config.
     pub fn allow_namespace<S: Into<String>>(&mut self, namespace: S) {
         self.allowed_namespaces.push(namespace.into())
+    }
+
+    pub fn preopened_dirs(&self) -> &[String] {
+        &self.preopened_dirs
+    }
+
+    /// Grant access to the given directory with this config.
+    pub fn preopen_dir<S: Into<String>>(&mut self, dir: S) {
+        self.preopened_dirs.push(dir.into())
     }
 
     pub fn plugins(&self) -> &Vec<Plugin> {
@@ -86,6 +97,7 @@ impl Default for EnvConfig {
                 String::from("lunatic::"),
                 String::from("wasi_snapshot_preview1::"),
             ],
+            preopened_dirs: vec![],
             plugins: vec![],
             wasi_args: None,
             wasi_envs: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,14 @@ async fn main() -> Result<()> {
                 .setting(ArgSettings::TakesValue),
         )
         .arg(
+            Arg::new("dir")
+                .long("dir")
+                .value_name("DIRECTORY")
+                .about("Grant access to the given host directory")
+                .setting(ArgSettings::MultipleOccurrences)
+                .setting(ArgSettings::TakesValue),
+        )
+        .arg(
             Arg::new("wasm")
                 .value_name("WASM")
                 .about("Entry .wasm file")
@@ -57,6 +65,11 @@ async fn main() -> Result<()> {
             let path = Path::new(plugin);
             let module = fs::read(path)?;
             config.add_plugin(module)?;
+        }
+    }
+    if let Some(dirs) = args.values_of("dir") {
+        for dir in dirs {
+            config.preopen_dir(dir);
         }
     }
     let env = Environment::new(config)?;

--- a/wat/all_imports.wat
+++ b/wat/all_imports.wat
@@ -35,6 +35,7 @@
     (import "lunatic::process" "create_config" (func (param i64 i64) (result i64)))
     (import "lunatic::process" "drop_config" (func (param i64)))
     (import "lunatic::process" "allow_namespace" (func (param i64 i32 i32)))
+    (import "lunatic::process" "preopen_dir" (func (param i64 i32 i32 i32) (result i32)))
     (import "lunatic::process" "add_plugin" (func (param i64 i32 i32 i32) (result i32)))
     (import "lunatic::process" "create_environment" (func (param i64 i32) (result i32)))
     (import "lunatic::process" "drop_environment" (func (param i64)))


### PR DESCRIPTION
This code proposes mechanisms for preopeninig directories with CLI and for spawned processes.

CLI example:
`lunatic --dir=. --dir=/tmp program.wasm`

Spawn process example (needs PR to rust-lib):
```Rust
use std::fs::File;
use std::io::Write;

use lunatic::{Config, Environment, Mailbox};

#[lunatic::main]
fn main(mailbox: Mailbox<()>) {
    let mut config = Config::new(17 * 64 * 1024, None);
    config.allow_namespace("");
    config.preopen_dir(".").unwrap();

    let mut enviroment = Environment::new(config).unwrap();
    let module = enviroment.add_this_module().unwrap();

    module.spawn_link(mailbox, |_mailbox: Mailbox<()>| {
        let mut file = File::create("./test.txt").unwrap();
        file.write_all(b"Hello, world!").unwrap();
    }).unwrap();
}
```

Spawned processes cant have access to directories that unavailable to host.