### PR TITLE
Add version API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 .DS_Store
+
+.vscode
+.idea

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@ mod mailbox;
 mod networking;
 pub(crate) mod plugin;
 mod process;
+mod version;
 mod wasi;
 
 use std::future::Future;
@@ -15,7 +16,7 @@ use wasmtime::{Caller, FuncType, IntoFunc, Linker, Memory, Trap, WasmRet, WasmTy
 use self::error::IntoTrap;
 use crate::state::ProcessState;
 
-// Registers all sub-APIs to the `Linker`
+// Registers all sub-APIs to the `Linker`.
 pub(crate) fn register(
     linker: &mut Linker<ProcessState>,
     namespace_filter: &[String],
@@ -25,6 +26,7 @@ pub(crate) fn register(
     mailbox::register(linker, namespace_filter)?;
     networking::register(linker, namespace_filter)?;
     wasi::register(linker, namespace_filter)?;
+    version::register(linker, namespace_filter)?;
     Ok(())
 }
 

--- a/src/api/version.rs
+++ b/src/api/version.rs
@@ -1,0 +1,48 @@
+use wasmtime::{FuncType, Linker, Trap, ValType};
+
+use crate::state::ProcessState;
+
+use super::link_if_match;
+
+/// Links the `version` APIs.
+pub(crate) fn register(
+    linker: &mut Linker<ProcessState>,
+    namespace_filter: &[String],
+) -> anyhow::Result<()> {
+    link_if_match(
+        linker,
+        "lunatic::version",
+        "major",
+        FuncType::new([], [ValType::I32]),
+        major_version,
+        namespace_filter,
+    )?;
+    link_if_match(
+        linker,
+        "lunatic::version",
+        "minor",
+        FuncType::new([], [ValType::I32]),
+        minor_version,
+        namespace_filter,
+    )?;
+    link_if_match(
+        linker,
+        "lunatic::version",
+        "patch",
+        FuncType::new([], [ValType::I32]),
+        patch_version,
+        namespace_filter,
+    )
+}
+
+fn major_version() -> Result<u32, Trap> {
+    Ok(env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().unwrap())
+}
+
+fn minor_version() -> Result<u32, Trap> {
+    Ok(env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().unwrap())
+}
+
+fn patch_version() -> Result<u32, Trap> {
+    Ok(env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().unwrap())
+}

--- a/wat/all_imports.wat
+++ b/wat/all_imports.wat
@@ -58,6 +58,10 @@
     (import "lunatic::process" "unregister" (func (param i32 i32 i32 i32 i64) (result i32)))
     (import "lunatic::process" "lookup" (func (param i32 i32 i32 i32 i32) (result i32)))
 
+    (import "lunatic::version" "major" (func (result i32)))
+    (import "lunatic::version" "minor" (func (result i32)))
+    (import "lunatic::version" "patch" (func (result i32)))
+
     ;; TODO: Add all WASI imports
 
     (func (export "hello") nop)


### PR DESCRIPTION
This provides a way to obtain the version of the runtime. This is useful because if the client and host are of different versions, then this could cause unsafe behavior.

- `lunatic::version::major` - returns an integer containing the major version of the runtime
- `lunatic::version::minor` - returns an integer containing the minor version of the runtime
- `lunatic::version::patch` - returns an integer containing the patch version of the runtime
