### PR TITLE
Tap testing - initial support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,7 @@ dependencies = [
  "pretty_assertions",
  "semver",
  "serde",
+ "testanything",
  "tokio",
  "uuid",
  "wabt",
@@ -1757,6 +1758,12 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "testanything"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee585f51c40e140775601bdacd703647940a3690ca4b9b25411af5b03a100255"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ semver = "^1.0"
 serde = "^1.0"
 bincode = "^1.3"
 dashmap = "^4.0"
+testanything = "0.3.0"
 
 [dev-dependencies]
 wat = "^1.0"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@ mod mailbox;
 mod networking;
 pub(crate) mod plugin;
 mod process;
+mod test;
 mod version;
 mod wasi;
 
@@ -27,6 +28,7 @@ pub(crate) fn register(
     networking::register(linker, namespace_filter)?;
     wasi::register(linker, namespace_filter)?;
     version::register(linker, namespace_filter)?;
+    test::register(linker, namespace_filter)?;
     Ok(())
 }
 

--- a/src/api/process.rs
+++ b/src/api/process.rs
@@ -295,7 +295,6 @@ pub(crate) fn register(
 //% Create a new configuration for an environment.
 fn create_config(mut caller: Caller<ProcessState>, max_memory: u64, max_fuel: u64) -> u64 {
     let max_fuel = if max_fuel != 0 { Some(max_fuel) } else { None };
-    caller.data_mut();
     let config = EnvConfig::new(max_memory as usize, max_fuel);
     caller.data_mut().resources.configs.add(config)
 }

--- a/src/api/process.rs
+++ b/src/api/process.rs
@@ -295,6 +295,7 @@ pub(crate) fn register(
 //% Create a new configuration for an environment.
 fn create_config(mut caller: Caller<ProcessState>, max_memory: u64, max_fuel: u64) -> u64 {
     let max_fuel = if max_fuel != 0 { Some(max_fuel) } else { None };
+    caller.data_mut();
     let config = EnvConfig::new(max_memory as usize, max_fuel);
     caller.data_mut().resources.configs.add(config)
 }

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -93,7 +93,7 @@ fn add_test_comment(mut caller: Caller<ProcessState>,
     node_id: u64,
     comment: u32,
     comment_len: u32,
-) -> Result<u64, Trap> {
+) -> Result<(), Trap> {
     let memory = get_memory(&mut caller)?;
 
     // get the buffer slice
@@ -108,7 +108,8 @@ fn add_test_comment(mut caller: Caller<ProcessState>,
     let parent = lock.get_mut(node_id)
         .or_trap("lunatic::test::add_test_comment")?;
     // parent.comments.push
-    Ok(child)
+    parent.add_comment(buffer);
+    Ok(())
 }
 
 

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -102,14 +102,12 @@ fn add_test_comment(mut caller: Caller<ProcessState>,
         .get(comment as usize..(comment + comment_len) as usize)
         .or_trap("lunatic::test::add_test_comment")?;
 
-    let node = TestNode::new(buffer);
     let mut lock = TESTS.lock()
         .or_trap("lunatic::test::add_test_comment")?;
 
-    let child = lock.add(node);
     let parent = lock.get_mut(node_id)
         .or_trap("lunatic::test::add_test_comment")?;
-    parent.push_child(child);
+    // parent.comments.push
     Ok(child)
 }
 
@@ -125,7 +123,7 @@ fn test_ok(mut _caller: Caller<ProcessState>,
     test_id: u64,
 ) -> Result<(), Trap> {
 
-    // get the 
+    // get the test, call ok()
 
     TESTS.lock()
         .or_trap("lunatic::test::test_ok")?

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -1,0 +1,138 @@
+// use std::convert::TryInto;
+// use std::future::Future;
+// use std::io::IoSlice;
+// use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+// use std::sync::Arc;
+// use std::time::Duration;
+
+use anyhow::Result;
+// use async_std::io::{ReadExt, WriteExt};
+// use async_std::net::{TcpListener, TcpStream, UdpSocket};
+use wasmtime::{Caller, Linker, FuncType, ValType};
+use wasmtime::{Trap};
+
+use crate::api::error::IntoTrap;
+// use crate::state::DnsIterator;
+use crate::{api::get_memory, state::ProcessState};
+use crate::test_node::{ TestNode, TESTS };
+use super::link_if_match;
+
+pub(crate) fn register(
+    linker: &mut Linker<ProcessState>,
+    namespace_filter: &[String],
+) -> Result<()> {
+    link_if_match(
+        linker,
+        "lunatic::test",
+        "add_test",
+        FuncType::new([ValType::I64, ValType::I32, ValType::I32], [ValType::I64]),
+        add_test,
+        namespace_filter,
+    )?;
+    link_if_match(
+        linker,
+        "lunatic::test",
+        "add_test_comment",
+        FuncType::new([ValType::I64, ValType::I32, ValType::I32], [ValType::I64]),
+        add_test_comment,
+        namespace_filter,
+    )?;
+    link_if_match(
+        linker,
+        "lunatic::test",
+        "test_ok",
+        FuncType::new([ValType::I64], []),
+        test_ok,
+        namespace_filter,
+    )?;
+    Ok(())
+}
+
+
+//% lunatic::test::add_test(parent_id: u64, name: u32, name_len: u32)
+//%
+//% Creates a global test node resource.
+//%
+//% Traps:
+//% * If the buffer + name_len is outside of memory
+//% * If the lock cannot be obtained
+//% * If the parent TestNode doesn't exist
+fn add_test(mut caller: Caller<ProcessState>,
+    parent_id: u64,
+    name: u32,
+    name_len: u32,
+) -> Result<u64, Trap> {
+    let memory = get_memory(&mut caller)?;
+
+    // get the buffer slice
+    let buffer = memory
+        .data_mut(&mut caller)
+        .get(name as usize..(name + name_len) as usize)
+        .or_trap("lunatic::test::add_test")?;
+
+    let node = TestNode::new(buffer);
+    let mut lock = TESTS.lock()
+        .or_trap("lunatic::test::add_test")?;
+
+    let child = lock.add(node);
+    let parent = lock.get_mut(parent_id)
+        .or_trap("lunatic::test::add_test")?;
+    parent.push_child(child);
+    Ok(child)
+}
+
+//% lunatic::test::add_test_comment(node_id: u64, name: u32, name_len: u32)
+//%
+//% Creates a global test node resource.
+//%
+//% Traps:
+//% * If the buffer + name_len is outside of memory
+//% * If the lock cannot be obtained
+//% * If the parent TestNode doesn't exist
+fn add_test_comment(mut caller: Caller<ProcessState>,
+    node_id: u64,
+    comment: u32,
+    comment_len: u32,
+) -> Result<u64, Trap> {
+    let memory = get_memory(&mut caller)?;
+
+    // get the buffer slice
+    let buffer = memory
+        .data_mut(&mut caller)
+        .get(comment as usize..(comment + comment_len) as usize)
+        .or_trap("lunatic::test::add_test_comment")?;
+
+    let node = TestNode::new(buffer);
+    let mut lock = TESTS.lock()
+        .or_trap("lunatic::test::add_test_comment")?;
+
+    let child = lock.add(node);
+    let parent = lock.get_mut(node_id)
+        .or_trap("lunatic::test::add_test_comment")?;
+    parent.push_child(child);
+    Ok(child)
+}
+
+
+//% lunatic::test::test_ok(test_id: u64)
+//%
+//% Denotes a test as OK
+//%
+//% Traps:
+//% * If the lock cannot be obtained
+//% * If the parent TestNode doesn't exist
+fn test_ok(mut _caller: Caller<ProcessState>,
+    test_id: u64,
+) -> Result<(), Trap> {
+
+    // get the 
+
+    TESTS.lock()
+        .or_trap("lunatic::test::test_ok")?
+        .get_mut(test_id)
+        .or_trap("lunatic::test::test_ok")?
+        .ok();
+
+    Ok(())
+}
+

--- a/src/api/test.rs
+++ b/src/api/test.rs
@@ -25,7 +25,7 @@ pub(crate) fn register(
         linker,
         "lunatic::test",
         "add_test",
-        FuncType::new([ValType::I64, ValType::I32, ValType::I32], [ValType::I64]),
+        FuncType::new([ValType::I64, ValType::I32, ValType::I32, ValType::I32], [ValType::I64]),
         add_test,
         namespace_filter,
     )?;
@@ -49,7 +49,7 @@ pub(crate) fn register(
 }
 
 
-//% lunatic::test::add_test(parent_id: u64, name: u32, name_len: u32)
+//% lunatic::test::add_test(parent_id: u64, name: u32, name_len: u32, negated: u32)
 //%
 //% Creates a global test node resource.
 //%
@@ -61,6 +61,7 @@ fn add_test(mut caller: Caller<ProcessState>,
     parent_id: u64,
     name: u32,
     name_len: u32,
+    negated: u32,
 ) -> Result<u64, Trap> {
     let memory = get_memory(&mut caller)?;
 
@@ -70,7 +71,7 @@ fn add_test(mut caller: Caller<ProcessState>,
         .get(name as usize..(name + name_len) as usize)
         .or_trap("lunatic::test::add_test")?;
 
-    let node = TestNode::new(buffer);
+    let node = TestNode::new(buffer, negated != 0);
     let mut lock = TESTS.lock()
         .or_trap("lunatic::test::add_test")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod plugin;
 pub(crate) mod process;
 pub mod registry;
 pub(crate) mod state;
+pub mod test_node;
 
 use async_std::sync::RwLock;
 use lazy_static::lazy_static;

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,10 @@ async fn main() -> Result<()> {
         }
 
         // TODO: Produce TAP output
+        // 1. Obtain lock from TESTS
+        // 2. Get record 0
+        // 3. call generate_tap
+
     } else {
         // Spawn main process
         let path = args.value_of("wasm").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::Path};
+use std::{env, fs, path::Path, borrow::BorrowMut};
 
 use async_std::channel;
 use clap::{crate_version, App, Arg, ArgSettings};
@@ -6,6 +6,7 @@ use clap::{crate_version, App, Arg, ArgSettings};
 use anyhow::{Context, Result};
 use lunatic_runtime::{node::Node, EnvConfig, Environment, NODE};
 use wasmtime::{ExternType};
+use lunatic_runtime::test_node::TESTS;
 
 #[async_std::main]
 async fn main() -> Result<()> {
@@ -177,6 +178,16 @@ async fn main() -> Result<()> {
         // 1. Obtain lock from TESTS
         // 2. Get record 0
         // 3. call generate_tap
+        let lock = TESTS.lock()
+            .expect("Lock expected.")
+            .borrow_mut();
+
+        let parent = lock.get(0)
+            .unwrap();
+
+        let builder = testanything::tap_suite_builder::TapSuiteBuilder::new();
+        parent.generate_tap(lock, &builder);
+        
 
     } else {
         // Spawn main process

--- a/src/module.rs
+++ b/src/module.rs
@@ -5,7 +5,7 @@ use async_std::channel::unbounded;
 use async_std::task::JoinHandle;
 use log::trace;
 use uuid::Uuid;
-use wasmtime::{Store, Val};
+use wasmtime::{ExportType, Store, Val};
 
 use std::sync::Arc;
 
@@ -52,6 +52,13 @@ impl Module {
         match self {
             Module::Local(local) => local.spawn(function, params, link).await,
             Module::Remote(remote) => remote.spawn(function, params, link).await,
+        }
+    }
+
+    pub fn exports<'a>(&'a self) -> Result<Box<dyn ExactSizeIterator<Item = ExportType<'a>> + 'a>> {
+        match self {
+            Module::Local(local) => Ok(Box::new(local.inner.wasmtime_module.exports())),
+            Module::Remote(_) => Err(anyhow!("Cannot get exports of remote module.")),
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,6 +18,7 @@ use crate::plugin::ModuleContext;
 use crate::{message::Message, EnvConfig, Environment};
 use crate::{Process, Signal};
 
+
 // The internal state of Plugins.
 pub(crate) struct PluginState<'a, 'b> {
     // Errors belonging to the plugin
@@ -149,7 +150,7 @@ pub(crate) struct Resources {
 }
 
 /// HashMap wrapper with incremental ID (u64) assignment.
-pub(crate) struct HashMapId<T> {
+pub struct HashMapId<T> {
     id_seed: u64,
     store: HashMap<u64, T>,
 }

--- a/src/test_node.rs
+++ b/src/test_node.rs
@@ -1,4 +1,4 @@
-use std::{ vec::Vec, sync::Mutex };
+use std::{ vec::Vec, sync::Mutex, str };
 use lazy_static::lazy_static;
 use testanything::{ tap_suite_builder::TapSuiteBuilder, tap_test_builder::TapTestBuilder };
 use crate::state::HashMapId;
@@ -13,7 +13,7 @@ pub struct TestNode {
 
 impl TestNode {
 
-    pub fn generate_tap(&self, map: &HashMapId<TestNode>, builder: &TapSuiteBuilder) -> () {
+    pub fn generate_tap(&self, map: &HashMapId<TestNode>, builder: &mut TapSuiteBuilder) -> () {
         let suite = TapTestBuilder::new()
             .name(self.name.as_str())
             .passed(self.ok);
@@ -25,9 +25,13 @@ impl TestNode {
             .finalize();
 
         builder.tests(vec![tap]);
-        for child in self.children {
+        for child in &self.children {
             // for each child, obtain the child, and call generate_tap on it
         }
+    }
+
+    pub fn add_comment(&mut self, comment: &[u8]) -> () {
+        self.comments.push_str(String::from_utf8_lossy(comment).into_owned().as_str());
     }
 
     pub fn new(name: &[u8]) -> TestNode {

--- a/src/test_node.rs
+++ b/src/test_node.rs
@@ -1,0 +1,53 @@
+use std::{ vec::Vec, sync::Mutex };
+use lazy_static::lazy_static;
+use testanything::{ tap_suite_builder::TapSuiteBuilder, tap_test_builder::TapTestBuilder };
+use crate::state::HashMapId;
+
+#[derive(Clone, Debug)]
+pub struct TestNode {
+    name: String,
+    children: Vec<u64>,
+    ok: bool,
+    comments: String,
+}
+
+impl TestNode {
+
+    pub fn generate_tap(&self, map: &HashMapId<TestNode>, builder: &TapSuiteBuilder) -> () {
+        let suite = TapTestBuilder::new()
+            .name(self.name.as_str())
+            .passed(self.ok);
+        let comments: Vec<&str> = self.comments.split("\r\n")
+            .into_iter()
+            .collect();
+        
+
+            
+    }
+
+    pub fn new(name: &[u8]) -> TestNode {
+        TestNode {
+            name: String::from_utf8_lossy(name).into_owned(),
+            children: Vec::new(),
+            ok: false,
+            comments: String::new(),
+        }
+    }
+
+    //% Push a child to this test node by it's id
+    pub fn push_child(&mut self, child_id: u64) -> () {
+        self.children.push(child_id);
+    }
+
+    pub fn ok(&mut self) -> () {
+        self.ok = true;
+    }
+}
+
+lazy_static!{
+    pub static ref TESTS: Mutex<HashMapId<TestNode>> = {
+        let mut hashmap = HashMapId::new();
+        hashmap.add(TestNode::new(b""));
+        Mutex::new(hashmap)
+    };
+}

--- a/src/test_node.rs
+++ b/src/test_node.rs
@@ -20,9 +20,14 @@ impl TestNode {
         let comments: Vec<&str> = self.comments.split("\r\n")
             .into_iter()
             .collect();
-        
+        let tap = suite
+            .diagnostics(comments.as_slice())
+            .finalize();
 
-            
+        builder.tests(vec![tap]);
+        for child in self.children {
+            // for each child, obtain the child, and call generate_tap on it
+        }
     }
 
     pub fn new(name: &[u8]) -> TestNode {


### PR DESCRIPTION
This pull request aims to add TAP testing support via a couple of mechanisms. 

- [x] Test functions are automatically called:
  - [x] Primary test entry is an exported `__lunatic_start_test` method
  - [x] Any function exported with the name `__lunatic_test` at the start will automatically be called and spawned in parallel.
- [x] A couple of exposed host functions
  - [x] `lunatic::test::add_test(parent_id: u64, name: u32, name_len: u32, negated: u32)` (Add a test to the test suite, and denote if it *should* fail)
  - [x] `lunatic::test::add_test_comment(node_id: u64, name: u32, name_len: u32)` (Add a comment to a test)
  - [x] `lunatic::test::test_ok(test_id: u64)`
- [ ] Write a file to the filesystem with tap output `--test ./build/output.tap`
- [ ] Consume the tap output in memory if `--report` flag is passed
