### PR TITLE
Refresh nodes after node registration to include itself

### DIFF
--- a/crates/lunatic-distributed/src/control/client.rs
+++ b/crates/lunatic-distributed/src/control/client.rs
@@ -56,11 +56,12 @@ impl Client {
         };
         // Spawn reader task before register
         tokio::task::spawn(reader_task(client.clone()));
-        tokio::task::spawn(refresh_nodes_task(client.clone()));
         let Registered {
             node_id,
             signed_cert,
         } = client.send_registration(signing_request).await?;
+        // Refresh nodes after registration
+        tokio::task::spawn(refresh_nodes_task(client.clone()));
 
         Ok((node_id, client, signed_cert))
     }

--- a/crates/lunatic-distributed/src/control/client.rs
+++ b/crates/lunatic-distributed/src/control/client.rs
@@ -56,12 +56,12 @@ impl Client {
         };
         // Spawn reader task before register
         tokio::task::spawn(reader_task(client.clone()));
+        tokio::task::spawn(refresh_nodes_task(client.clone()));
         let Registered {
             node_id,
             signed_cert,
         } = client.send_registration(signing_request).await?;
-        // Refresh nodes after registration
-        tokio::task::spawn(refresh_nodes_task(client.clone()));
+        client.refresh_nodes().await?;
 
         Ok((node_id, client, signed_cert))
     }


### PR DESCRIPTION
Resolves #120 

Registration to the control is done before executing `.wasm`. 
Issue was due to starting `refresh_nodes_task` before registration. The task would sleep for 5 secs before refreshing nodes again with the control node.

Now the following will work as expected

```rust
// list_test.rs
fn main() {
    let nodes = lunatic::distributed::nodes();
    let node_id = lunatic::distributed::node_id();
    println!("{:?}", nodes);
    println!("{node_id}");
}
```

Output

```
[1]
1
```

Run example
```
lunatic --control 127.0.0.1:12345 --control-server --test-ca --no-entry
lunatic --control 127.0.0.1:12345 --node 127.0.0.1:10000 --test-ca target/wasm32-wasi/release/list_test.wasm
```