### PR TITLE
Shared compiled wasm modules

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -17,9 +17,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let runtime = WasmtimeRuntime::new(&wasmtime_config).unwrap();
 
     let raw_module = wat::parse_file("./wat/hello.wat").unwrap();
-    let module = runtime
-        .compile_module::<DefaultProcessState>(raw_module.into())
-        .unwrap();
+    let module = Arc::new(runtime.compile_module(raw_module.into()).unwrap());
 
     let env = Environment::new(0);
     c.bench_function("spawn process", |b| {
@@ -34,20 +32,13 @@ fn criterion_benchmark(c: &mut Criterion) {
                 registry,
             )
             .unwrap();
-            env.spawn_wasm(
-                runtime.clone(),
-                module.clone(),
-                state,
-                "hello",
-                Vec::new(),
-                None,
-            )
-            .await
-            .unwrap()
-            .0
-            .await
-            .unwrap()
-            .ok();
+            env.spawn_wasm(runtime.clone(), &module, state, "hello", Vec::new(), None)
+                .await
+                .unwrap()
+                .0
+                .await
+                .unwrap()
+                .ok();
         });
     });
 }

--- a/crates/lunatic-distributed-api/src/lib.rs
+++ b/crates/lunatic-distributed-api/src/lib.rs
@@ -14,7 +14,7 @@ use wasmtime::{Caller, Linker, ResourceLimiter, Trap};
 // Register the lunatic distributed APIs to the linker
 pub fn register<T>(linker: &mut Linker<T>) -> Result<()>
 where
-    T: DistributedCtx + ProcessCtx<T> + Send + ResourceLimiter + 'static,
+    T: DistributedCtx + ProcessCtx + Send + ResourceLimiter + 'static,
     for<'a> &'a T: Send,
 {
     linker.func_wrap("lunatic::distributed", "nodes_count", nodes_count)?;
@@ -194,7 +194,7 @@ fn send<T>(
     process_id: u64,
 ) -> Box<dyn Future<Output = Result<(), Trap>> + Send + '_>
 where
-    T: DistributedCtx + ProcessCtx<T> + Send + 'static,
+    T: DistributedCtx + ProcessCtx + Send + 'static,
     for<'a> &'a T: Send,
 {
     Box::new(async move {
@@ -252,7 +252,7 @@ fn send_receive_skip_search<T>(
     timeout_duration: u64,
 ) -> Box<dyn Future<Output = Result<u32, Trap>> + Send + '_>
 where
-    T: DistributedCtx + ProcessCtx<T> + Send + 'static,
+    T: DistributedCtx + ProcessCtx + Send + 'static,
     for<'a> &'a T: Send,
 {
     Box::new(async move {

--- a/crates/lunatic-distributed/src/distributed/server.rs
+++ b/crates/lunatic-distributed/src/distributed/server.rs
@@ -19,22 +19,12 @@ use crate::{
 
 use super::message::Spawn;
 
-pub struct ServerCtx<T> {
+#[derive(Clone)]
+pub struct ServerCtx {
     pub envs: Environments,
-    pub modules: Modules<T>,
+    pub modules: Modules,
     pub distributed: DistributedProcessState,
     pub runtime: WasmtimeRuntime,
-}
-
-impl<T: 'static> Clone for ServerCtx<T> {
-    fn clone(&self) -> Self {
-        Self {
-            envs: self.envs.clone(),
-            modules: self.modules.clone(),
-            distributed: self.distributed.clone(),
-            runtime: self.runtime.clone(),
-        }
-    }
 }
 
 pub fn root_cert(test_ca: bool, ca_cert: Option<&str>) -> Result<String> {
@@ -59,7 +49,7 @@ pub fn gen_node_cert(node_name: &str) -> Result<Certificate> {
 }
 
 pub async fn node_server<T>(
-    ctx: ServerCtx<T>,
+    ctx: ServerCtx,
     socket: SocketAddr,
     cert: String,
     key: String,
@@ -68,31 +58,31 @@ where
     T: ProcessState + ResourceLimiter + DistributedCtx + Send + 'static,
 {
     let mut quic_server = quic::new_quic_server(socket, &cert, &key)?;
-    quic::handle_node_server(&mut quic_server, ctx.clone()).await?;
+    quic::handle_node_server::<T>(&mut quic_server, ctx.clone()).await?;
     Ok(())
 }
 
-pub async fn handle_message<T>(ctx: ServerCtx<T>, conn: quic::Connection, msg_id: u64, msg: Request)
+pub async fn handle_message<T>(ctx: ServerCtx, conn: quic::Connection, msg_id: u64, msg: Request)
 where
-    T: ProcessState + DistributedCtx + ResourceLimiter + Send + 'static,
+    T: ProcessState + ResourceLimiter + DistributedCtx + Send + 'static,
 {
-    if let Err(e) = handle_message_err(ctx, conn, msg_id, msg).await {
+    if let Err(e) = handle_message_err::<T>(ctx, conn, msg_id, msg).await {
         log::error!("Error handling message: {e}");
     }
 }
 
 async fn handle_message_err<T>(
-    ctx: ServerCtx<T>,
+    ctx: ServerCtx,
     conn: quic::Connection,
     msg_id: u64,
     msg: Request,
 ) -> Result<()>
 where
-    T: ProcessState + DistributedCtx + ResourceLimiter + Send + 'static,
+    T: ProcessState + ResourceLimiter + DistributedCtx + Send + 'static,
 {
     match msg {
         Request::Spawn(spawn) => {
-            let id = handle_spawn(ctx, spawn).await?;
+            let id = handle_spawn::<T>(ctx, spawn).await?;
             conn.send(msg_id, Response::Spawned(id)).await?;
         }
         Request::Message {
@@ -105,9 +95,9 @@ where
     Ok(())
 }
 
-async fn handle_spawn<T>(mut ctx: ServerCtx<T>, spawn: Spawn) -> Result<u64>
+async fn handle_spawn<T>(mut ctx: ServerCtx, spawn: Spawn) -> Result<u64>
 where
-    T: ProcessState + DistributedCtx + ResourceLimiter + Send + 'static,
+    T: ProcessState + ResourceLimiter + DistributedCtx + Send + 'static,
 {
     let Spawn {
         environment_id,
@@ -125,7 +115,9 @@ where
         None => {
             if let Some(bytes) = ctx.distributed.control.get_module(module_id).await {
                 let wasm = RawWasm::new(Some(module_id), bytes);
-                ctx.modules.compile(ctx.runtime.clone(), wasm).await??
+                ctx.modules
+                    .compile::<T>(ctx.runtime.clone(), wasm)
+                    .await??
             } else {
                 return Err(anyhow!("Cannot get the module from control"));
             }
@@ -138,21 +130,18 @@ where
     let state = T::new_dist_state(env.clone(), distributed, runtime, module.clone(), config)?;
     let params: Vec<wasmtime::Val> = params.into_iter().map(Into::into).collect();
     let (_handle, proc) = env
-        .spawn_wasm(ctx.runtime, module, state, &function, params, None)
+        .spawn_wasm::<T>(ctx.runtime, &module, state, &function, params, None)
         .await?;
     Ok(proc.id())
 }
 
-async fn handle_process_message<T>(
-    mut ctx: ServerCtx<T>,
+async fn handle_process_message(
+    mut ctx: ServerCtx,
     environment_id: u64,
     process_id: u64,
     tag: Option<i64>,
     data: Vec<u8>,
-) -> Result<()>
-where
-    T: ProcessState + DistributedCtx + ResourceLimiter + Send + 'static,
-{
+) -> Result<()> {
     let env = ctx.envs.get_or_create(environment_id);
     if let Some(proc) = env.get_process(process_id) {
         proc.send(Signal::Message(Message::Data(DataMessage::new_from_vec(

--- a/crates/lunatic-distributed/src/lib.rs
+++ b/crates/lunatic-distributed/src/lib.rs
@@ -15,7 +15,7 @@ pub trait DistributedCtx: ProcessState + Sized {
         environment: Environment,
         distributed: DistributedProcessState,
         runtime: WasmtimeRuntime,
-        module: WasmtimeCompiledModule<Self>,
+        module: Arc<WasmtimeCompiledModule>,
         config: Arc<Self::Config>,
     ) -> Result<Self>;
     fn distributed(&self) -> Result<&DistributedProcessState>;

--- a/crates/lunatic-messaging-api/src/lib.rs
+++ b/crates/lunatic-messaging-api/src/lib.rs
@@ -18,7 +18,7 @@ use lunatic_process::{
 };
 
 // Register the mailbox APIs to the linker
-pub fn register<T: ProcessState + ProcessCtx<T> + NetworkingCtx + Send + 'static>(
+pub fn register<T: ProcessState + ProcessCtx + NetworkingCtx + Send + 'static>(
     linker: &mut Linker<T>,
 ) -> Result<()> {
     linker.func_wrap("lunatic::message", "create_data", create_data)?;
@@ -27,6 +27,8 @@ pub fn register<T: ProcessState + ProcessCtx<T> + NetworkingCtx + Send + 'static
     linker.func_wrap("lunatic::message", "seek_data", seek_data)?;
     linker.func_wrap("lunatic::message", "get_tag", get_tag)?;
     linker.func_wrap("lunatic::message", "data_size", data_size)?;
+    linker.func_wrap("lunatic::message", "push_module", push_module)?;
+    linker.func_wrap("lunatic::message", "take_module", take_module)?;
     linker.func_wrap("lunatic::message", "push_tcp_stream", push_tcp_stream)?;
     linker.func_wrap("lunatic::message", "take_tcp_stream", take_tcp_stream)?;
     linker.func_wrap("lunatic::message", "send", send)?;
@@ -118,7 +120,7 @@ pub fn register<T: ProcessState + ProcessCtx<T> + NetworkingCtx + Send + 'static
 // Arguments:
 // * tag - An identifier that can be used for selective receives. If value is 0, no tag is used.
 // * buffer_capacity - A hint to the message to pre-allocate a large enough buffer for writes.
-fn create_data<T: ProcessState + ProcessCtx<T>>(
+fn create_data<T: ProcessState + ProcessCtx>(
     mut caller: Caller<T>,
     tag: i64,
     buffer_capacity: u64,
@@ -139,7 +141,7 @@ fn create_data<T: ProcessState + ProcessCtx<T>>(
 // Traps:
 // * If any memory outside the guest heap space is referenced.
 // * If it's called without a data message being inside of the scratch area.
-fn write_data<T: ProcessState + ProcessCtx<T>>(
+fn write_data<T: ProcessState + ProcessCtx>(
     mut caller: Caller<T>,
     data_ptr: u32,
     data_len: u32,
@@ -171,7 +173,7 @@ fn write_data<T: ProcessState + ProcessCtx<T>>(
 // Traps:
 // * If any memory outside the guest heap space is referenced.
 // * If it's called without a data message being inside of the scratch area.
-fn read_data<T: ProcessState + ProcessCtx<T>>(
+fn read_data<T: ProcessState + ProcessCtx>(
     mut caller: Caller<T>,
     data_ptr: u32,
     data_len: u32,
@@ -204,10 +206,7 @@ fn read_data<T: ProcessState + ProcessCtx<T>>(
 //
 // Traps:
 // * If it's called without a data message being inside of the scratch area.
-fn seek_data<T: ProcessState + ProcessCtx<T>>(
-    mut caller: Caller<T>,
-    index: u64,
-) -> Result<(), Trap> {
+fn seek_data<T: ProcessState + ProcessCtx>(mut caller: Caller<T>, index: u64) -> Result<(), Trap> {
     let mut message = caller
         .data_mut()
         .message_scratch_area()
@@ -226,7 +225,7 @@ fn seek_data<T: ProcessState + ProcessCtx<T>>(
 //
 // Traps:
 // * If it's called without a message being inside of the scratch area.
-fn get_tag<T: ProcessState + ProcessCtx<T>>(mut caller: Caller<T>) -> Result<i64, Trap> {
+fn get_tag<T: ProcessState + ProcessCtx>(mut caller: Caller<T>) -> Result<i64, Trap> {
     let message = caller
         .data_mut()
         .message_scratch_area()
@@ -242,7 +241,7 @@ fn get_tag<T: ProcessState + ProcessCtx<T>>(mut caller: Caller<T>) -> Result<i64
 //
 // Traps:
 // * If it's called without a data message being inside of the scratch area.
-fn data_size<T: ProcessState + ProcessCtx<T>>(mut caller: Caller<T>) -> Result<u64, Trap> {
+fn data_size<T: ProcessState + ProcessCtx>(mut caller: Caller<T>) -> Result<u64, Trap> {
     let message = caller
         .data_mut()
         .message_scratch_area()
@@ -258,13 +257,69 @@ fn data_size<T: ProcessState + ProcessCtx<T>>(mut caller: Caller<T>) -> Result<u
     Ok(bytes as u64)
 }
 
+// Adds a module resource to the message that is currently in the scratch area and returns
+// the new location of it.
+//
+// Traps:
+// * If module ID doesn't exist
+// * If no data message is in the scratch area.
+fn push_module<T: ProcessState + ProcessCtx + NetworkingCtx>(
+    mut caller: Caller<T>,
+    module_id: u64,
+) -> Result<u64, Trap> {
+    let module = caller
+        .data()
+        .module_resources()
+        .get(module_id)
+        .or_trap("lunatic::message::push_module")?
+        .clone();
+    let message = caller
+        .data_mut()
+        .message_scratch_area()
+        .as_mut()
+        .or_trap("lunatic::message::push_module")?;
+    let index = match message {
+        Message::Data(data) => data.add_module(module) as u64,
+        Message::LinkDied(_) => {
+            return Err(Trap::new("Unexpected `Message::LinkDied` in scratch area"))
+        }
+    };
+    Ok(index)
+}
+
+// Takes the module from the message that is currently in the scratch area by index, puts
+// it into the process' resources and returns the resource ID.
+//
+// Traps:
+// * If index ID doesn't exist or matches the wrong resource (not a module).
+// * If no data message is in the scratch area.
+fn take_module<T: ProcessState + ProcessCtx + NetworkingCtx>(
+    mut caller: Caller<T>,
+    index: u64,
+) -> Result<u64, Trap> {
+    let message = caller
+        .data_mut()
+        .message_scratch_area()
+        .as_mut()
+        .or_trap("lunatic::message::take_module")?;
+    let module = match message {
+        Message::Data(data) => data
+            .take_module(index as usize)
+            .or_trap("lunatic::message::take_module")?,
+        Message::LinkDied(_) => {
+            return Err(Trap::new("Unexpected `Message::LinkDied` in scratch area"))
+        }
+    };
+    Ok(caller.data_mut().module_resources_mut().add(module))
+}
+
 // Adds a tcp stream resource to the message that is currently in the scratch area and returns
-// the new location of it. This will remove the tcp stream from  the current process' resources.
+// the new location of it. This will remove the tcp stream from the current process' resources.
 //
 // Traps:
 // * If TCP stream ID doesn't exist
 // * If no data message is in the scratch area.
-fn push_tcp_stream<T: ProcessState + ProcessCtx<T> + NetworkingCtx>(
+fn push_tcp_stream<T: ProcessState + ProcessCtx + NetworkingCtx>(
     mut caller: Caller<T>,
     stream_id: u64,
 ) -> Result<u64, Trap> {
@@ -293,7 +348,7 @@ fn push_tcp_stream<T: ProcessState + ProcessCtx<T> + NetworkingCtx>(
 // Traps:
 // * If index ID doesn't exist or matches the wrong resource (not a tcp stream).
 // * If no data message is in the scratch area.
-fn take_tcp_stream<T: ProcessState + ProcessCtx<T> + NetworkingCtx>(
+fn take_tcp_stream<T: ProcessState + ProcessCtx + NetworkingCtx>(
     mut caller: Caller<T>,
     index: u64,
 ) -> Result<u64, Trap> {
@@ -320,10 +375,7 @@ fn take_tcp_stream<T: ProcessState + ProcessCtx<T> + NetworkingCtx>(
 // Traps:
 // * If the process ID doesn't exist.
 // * If it's called before creating the next message.
-fn send<T: ProcessState + ProcessCtx<T>>(
-    mut caller: Caller<T>,
-    process_id: u64,
-) -> Result<(), Trap> {
+fn send<T: ProcessState + ProcessCtx>(mut caller: Caller<T>, process_id: u64) -> Result<(), Trap> {
     let message = caller
         .data_mut()
         .message_scratch_area()
@@ -355,7 +407,7 @@ fn send<T: ProcessState + ProcessCtx<T>>(
 // Traps:
 // * If the process ID doesn't exist.
 // * If it's called with wrong data in the scratch area.
-fn send_receive_skip_search<T: ProcessState + ProcessCtx<T> + Send>(
+fn send_receive_skip_search<T: ProcessState + ProcessCtx + Send>(
     mut caller: Caller<T>,
     process_id: u64,
     timeout_duration: u64,
@@ -414,7 +466,7 @@ fn send_receive_skip_search<T: ProcessState + ProcessCtx<T> + Send>(
 //
 // Traps:
 // * If **tag_ptr + (ciovec_array_len * 8) is outside the memory
-fn receive<T: ProcessState + ProcessCtx<T> + Send>(
+fn receive<T: ProcessState + ProcessCtx + Send>(
     mut caller: Caller<T>,
     tag_ptr: u32,
     tag_len: u32,
@@ -464,7 +516,7 @@ fn receive<T: ProcessState + ProcessCtx<T> + Send>(
 // Traps:
 // * If UDP socket ID doesn't exist
 // * If no data message is in the scratch area.
-fn push_udp_socket<T: ProcessState + ProcessCtx<T> + NetworkingCtx>(
+fn push_udp_socket<T: ProcessState + ProcessCtx + NetworkingCtx>(
     mut caller: Caller<T>,
     socket_id: u64,
 ) -> Result<u64, Trap> {
@@ -492,7 +544,7 @@ fn push_udp_socket<T: ProcessState + ProcessCtx<T> + NetworkingCtx>(
 // Traps:
 // * If index ID doesn't exist or matches the wrong resource (not a udp socket).
 // * If no data message is in the scratch area.
-fn take_udp_socket<T: ProcessState + ProcessCtx<T> + NetworkingCtx>(
+fn take_udp_socket<T: ProcessState + ProcessCtx + NetworkingCtx>(
     mut caller: Caller<T>,
     index: u64,
 ) -> Result<u64, Trap> {

--- a/crates/lunatic-process/src/state.rs
+++ b/crates/lunatic-process/src/state.rs
@@ -31,11 +31,9 @@ pub trait ProcessState: Sized {
     // This is used in the guest function `spawn` which uses this trait and not the concrete state.
     fn new_state(
         &self,
-        module: WasmtimeCompiledModule<Self>,
+        module: Arc<WasmtimeCompiledModule>,
         config: Arc<Self::Config>,
     ) -> Result<Self>;
-
-    fn state_for_instantiation() -> Self;
 
     /// Register all host functions to the linker.
     fn register(linker: &mut Linker<Self>) -> Result<()>;
@@ -47,7 +45,7 @@ pub trait ProcessState: Sized {
     /// Returns the WebAssembly runtime
     fn runtime(&self) -> &WasmtimeRuntime;
     // Returns the WebAssembly module
-    fn module(&self) -> &WasmtimeCompiledModule<Self>;
+    fn module(&self) -> &Arc<WasmtimeCompiledModule>;
     /// Returns the process configuration
     fn config(&self) -> &Arc<Self::Config>;
 

--- a/crates/lunatic-process/src/wasm.rs
+++ b/crates/lunatic-process/src/wasm.rs
@@ -23,7 +23,7 @@ impl Environment {
     pub async fn spawn_wasm<S>(
         &self,
         runtime: WasmtimeRuntime,
-        module: WasmtimeCompiledModule<S>,
+        module: &WasmtimeCompiledModule,
         state: S,
         function: &str,
         params: Vec<Val>,
@@ -38,7 +38,7 @@ impl Environment {
         let signal_mailbox = state.signal_mailbox().clone();
         let message_mailbox = state.message_mailbox().clone();
 
-        let instance = runtime.instantiate(&module, state).await?;
+        let instance = runtime.instantiate(module, state).await?;
         let function = function.to_string();
         let fut = async move { instance.call(&function, params).await };
         let child_process = crate::new(fut, id, self.clone(), signal_mailbox.1, message_mailbox);

--- a/crates/lunatic-registry-api/src/lib.rs
+++ b/crates/lunatic-registry-api/src/lib.rs
@@ -6,7 +6,7 @@ use wasmtime::Trap;
 use wasmtime::{Caller, Linker};
 
 // Register the registry APIs to the linker
-pub fn register<T: ProcessState + ProcessCtx<T> + 'static>(linker: &mut Linker<T>) -> Result<()> {
+pub fn register<T: ProcessState + ProcessCtx + 'static>(linker: &mut Linker<T>) -> Result<()> {
     linker.func_wrap("lunatic::registry", "put", put)?;
     linker.func_wrap("lunatic::registry", "get", get)?;
     linker.func_wrap("lunatic::registry", "remove", remove)?;
@@ -18,7 +18,7 @@ pub fn register<T: ProcessState + ProcessCtx<T> + 'static>(linker: &mut Linker<T
 // Traps:
 // * If the process ID doesn't exist.
 // * If any memory outside the guest heap space is referenced.
-fn put<T: ProcessState + ProcessCtx<T>>(
+fn put<T: ProcessState + ProcessCtx>(
     mut caller: Caller<T>,
     name_str_ptr: u32,
     name_str_len: u32,
@@ -43,7 +43,7 @@ fn put<T: ProcessState + ProcessCtx<T>>(
 //
 // Traps:
 // * If any memory outside the guest heap space is referenced.
-fn get<T: ProcessState + ProcessCtx<T>>(
+fn get<T: ProcessState + ProcessCtx>(
     mut caller: Caller<T>,
     name_str_ptr: u32,
     name_str_len: u32,
@@ -81,7 +81,7 @@ fn get<T: ProcessState + ProcessCtx<T>>(
 //
 // Traps:
 // * If any memory outside the guest heap space is referenced.
-fn remove<T: ProcessState + ProcessCtx<T>>(
+fn remove<T: ProcessState + ProcessCtx>(
     mut caller: Caller<T>,
     name_str_ptr: u32,
     name_str_len: u32,

--- a/crates/lunatic-timer-api/src/lib.rs
+++ b/crates/lunatic-timer-api/src/lib.rs
@@ -84,7 +84,7 @@ pub trait TimerCtx {
     fn timer_resources_mut(&mut self) -> &mut TimerResources;
 }
 
-pub fn register<T: ProcessState + ProcessCtx<T> + TimerCtx + Send + 'static>(
+pub fn register<T: ProcessState + ProcessCtx + TimerCtx + Send + 'static>(
     linker: &mut Linker<T>,
 ) -> Result<()> {
     linker.func_wrap("lunatic::timer", "send_after", send_after)?;
@@ -99,7 +99,7 @@ pub fn register<T: ProcessState + ProcessCtx<T> + TimerCtx + Send + 'static>(
 // Traps:
 // * If the process ID doesn't exist.
 // * If it's called before creating the next message.
-fn send_after<T: ProcessState + ProcessCtx<T> + TimerCtx>(
+fn send_after<T: ProcessState + ProcessCtx + TimerCtx>(
     mut caller: Caller<T>,
     process_id: u64,
     delay: u64,

--- a/src/mode/cargo_test.rs
+++ b/src/mode/cargo_test.rs
@@ -125,7 +125,7 @@ pub(crate) async fn test() -> Result<()> {
     let path = args.value_of("wasm").unwrap();
     let path = Path::new(path);
     let module = fs::read(path)?;
-    let module = runtime.compile_module::<DefaultProcessState>(module.into())?;
+    let module = Arc::new(runtime.compile_module(module.into())?);
 
     let filter = args.value_of("filter").unwrap_or_default();
     let exact = args.is_present("exact");
@@ -275,7 +275,7 @@ pub(crate) async fn test() -> Result<()> {
         let (task, _) = env
             .spawn_wasm(
                 runtime.clone(),
-                module.clone(),
+                &module,
                 state,
                 &test_function.wasm_export_name,
                 Vec::new(),


### PR DESCRIPTION
Allows compiled wasm modules to be shared between the same node.

Two new host functions were added:
- `"lunatic::message::push_module"`
- `"lunatic::message::take_module"`

Modules are no longer pre-linked. The upside of this is that `WasmtimeCompiledModule` no longer has a generic (which removes generics from many other places too), but the downside is that it might be a little less performant.

I'll try to get some benchmarks done to test this PR's performance compared to before.