### PR TITLE
Slightly improve error reporting in two cases.

### DIFF
--- a/crates/lunatic-process/src/runtimes/wasmtime.rs
+++ b/crates/lunatic-process/src/runtimes/wasmtime.rs
@@ -164,9 +164,10 @@ where
                                 ResultValue::Failed(trap.to_string())
                             }
                         }
-                        None => {
-                            ResultValue::Failed("Can't downcast trap to wasmtime::Trap".to_string())
-                        }
+                        None => ResultValue::Failed(format!(
+                            "Can't downcast trap ({}) to wasmtime::Trap",
+                            err
+                        )),
                     }
                 }
             },


### PR DESCRIPTION
Caveat emptor: I really have no idea if this is the right approach in either case :)

1. When wasmtime returns a non-Trap error, include that error's string repr in the unhandled case.
2. When a guest calls spawn with a params array that is not a multiple of 17, return an error.