### PR TITLE
Add Metrics to VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,7 @@ dependencies = [
  "lunatic-process",
  "lunatic-stdout-capture",
  "lunatic-wasi-api",
+ "metrics",
  "tokio",
  "wasmtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "hash-map-id",
  "log",
  "lunatic-networking-api",
+ "metrics",
  "serde",
  "tokio",
  "wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,10 +1069,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.3",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.3",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "indexmap"
@@ -1404,6 +1461,7 @@ dependencies = [
  "lunatic-version-api",
  "lunatic-wasi-api",
  "metrics",
+ "metrics-exporter-prometheus",
  "regex",
  "serde",
  "tokio",
@@ -1525,6 +1583,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-prometheus"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
+dependencies = [
+ "hyper",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "metrics-macros"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1610,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d24dc2dbae22bff6f1f9326ffce828c9f07ef9cc1e8002e5279f845432a30a"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils 0.8.11",
+ "hashbrown",
+ "metrics",
+ "num_cpus",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -1843,6 +1937,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
+dependencies = [
+ "crossbeam-utils 0.8.11",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,6 +2083,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2410,6 +2529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb945e54128e09c43d8e4f1277851bd5044c6fc540bbaa2ad888f60b3da9ae7"
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,6 +2791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,6 +2828,12 @@ checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
@@ -2767,10 +2904,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "lunatic-common-api",
  "lunatic-process",
  "lunatic-process-api",
+ "metrics",
  "tokio",
  "wasmtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
  "lunatic-common-api",
  "lunatic-process",
  "lunatic-process-api",
+ "metrics",
  "wasmtime",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ dependencies = [
  "lunatic-timer-api",
  "lunatic-version-api",
  "lunatic-wasi-api",
+ "metrics",
  "regex",
  "serde",
  "tokio",
@@ -1509,6 +1510,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+dependencies = [
+ "ahash",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1757,6 +1780,12 @@ checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,11 @@ default = ["distributed-quinn", "metrics"]
 distributed-tcp = ["lunatic-distributed/tcp"]
 distributed-s2n = ["lunatic-distributed/quic-s2n"]
 distributed-quinn = ["lunatic-distributed/quic-quinn"]
-metrics = ["dep:metrics", "lunatic-timer-api/metrics"]
+metrics = [
+    "dep:metrics",
+    "lunatic-timer-api/metrics",
+    "lunatic-registry-api/metrics",
+]
 prometheus = ["dep:metrics-exporter-prometheus", "metrics"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ distributed-tcp = ["lunatic-distributed/tcp"]
 distributed-s2n = ["lunatic-distributed/quic-s2n"]
 distributed-quinn = ["lunatic-distributed/quic-quinn"]
 metrics = ["dep:metrics", "lunatic-timer-api/metrics"]
+prometheus = ["dep:metrics-exporter-prometheus", "metrics"]
 
 [dependencies]
 anyhow = "^1.0"
@@ -46,6 +47,7 @@ bincode = "^1.3"
 dashmap = "^5.3.4"
 regex = "^1.5"
 metrics = { version = "0.20.1", optional = true }
+metrics-exporter-prometheus = { version = "0.11.0", optional = true }
 uuid = { version = "^1.1", features = ["v4"] }
 hash-map-id = { version = "^0.10", path = "crates/hash-map-id" }
 lunatic-stdout-capture = { version = "^0.10", path = "crates/lunatic-stdout-capture" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,22 @@ name = "lunatic"
 path = "src/main.rs"
 
 [features]
-default = ["distributed-quinn"]
+default = ["distributed-quinn", "metrics"]
 distributed-tcp = ["lunatic-distributed/tcp"]
 distributed-s2n = ["lunatic-distributed/quic-s2n"]
 distributed-quinn = ["lunatic-distributed/quic-quinn"]
+metrics = ["dep:metrics"]
 
 [dependencies]
 anyhow = "^1.0"
 clap = { version = "^3.2", features = ["cargo"] }
 lazy_static = "^1.4"
-tokio = { version = "^1.20", features = ["macros", "rt-multi-thread", "net", "time"] }
+tokio = { version = "^1.20", features = [
+    "macros",
+    "rt-multi-thread",
+    "net",
+    "time",
+] }
 wasmtime = "^0.40"
 wasmtime-wasi = "^0.40"
 wasi-common = "^0.40"
@@ -39,6 +45,7 @@ serde = "^1.0"
 bincode = "^1.3"
 dashmap = "^5.3.4"
 regex = "^1.5"
+metrics = { version = "0.20.1", optional = true }
 uuid = { version = "^1.1", features = ["v4"] }
 hash-map-id = { version = "^0.10", path = "crates/hash-map-id" }
 lunatic-stdout-capture = { version = "^0.10", path = "crates/lunatic-stdout-capture" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ metrics = [
     "dep:metrics",
     "lunatic-timer-api/metrics",
     "lunatic-registry-api/metrics",
+    "lunatic-process-api/metrics",
 ]
 prometheus = ["dep:metrics-exporter-prometheus", "metrics"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ metrics = [
     "lunatic-timer-api/metrics",
     "lunatic-registry-api/metrics",
     "lunatic-process-api/metrics",
+    "lunatic-process/metrics",
 ]
 prometheus = ["dep:metrics-exporter-prometheus", "metrics"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["distributed-quinn", "metrics"]
 distributed-tcp = ["lunatic-distributed/tcp"]
 distributed-s2n = ["lunatic-distributed/quic-s2n"]
 distributed-quinn = ["lunatic-distributed/quic-quinn"]
-metrics = ["dep:metrics"]
+metrics = ["dep:metrics", "lunatic-timer-api/metrics"]
 
 [dependencies]
 anyhow = "^1.0"

--- a/crates/lunatic-process-api/Cargo.toml
+++ b/crates/lunatic-process-api/Cargo.toml
@@ -10,9 +10,13 @@ license = "Apache-2.0/MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+metrics = ["dep:metrics"]
+
 [dependencies]
 anyhow = "^1.0"
 wasmtime = "^0.40"
+metrics = { version = "0.20.1", optional = true }
 tokio = { version = "^1.20", features = ["macros", "time"] }
 hash-map-id = { version = "^0.10", path = "../hash-map-id" }
 lunatic-stdout-capture = { version = "^0.10", path = "../lunatic-stdout-capture" }

--- a/crates/lunatic-process-api/src/lib.rs
+++ b/crates/lunatic-process-api/src/lib.rs
@@ -49,6 +49,9 @@ where
     T::Config: ProcessConfigCtx,
 {
     #[cfg(feature = "metrics")]
+    lunatic_process::describe_metrics();
+
+    #[cfg(feature = "metrics")]
     metrics::describe_counter!(
         "lunatic.process.modules.compiled",
         metrics::Unit::Count,

--- a/crates/lunatic-process/Cargo.toml
+++ b/crates/lunatic-process/Cargo.toml
@@ -10,11 +10,23 @@ license = "Apache-2.0/MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+metrics = ["dep:metrics"]
+
+# Disabled by default as it will usually lead to giant metrics exports
+detailed_metrics = ["metrics"]
+
 [dependencies]
 anyhow = "^1.0"
 log = "^0.4"
 dashmap = "5.3.4"
-tokio = { version = "^1.20", features = ["macros", "rt-multi-thread", "sync", "net"] }
+metrics = { version = "0.20.1", optional = true }
+tokio = { version = "^1.20", features = [
+    "macros",
+    "rt-multi-thread",
+    "sync",
+    "net",
+] }
 wasmtime = "^0.40"
 serde = "^1.0"
 hash-map-id = { version = "^0.10", path = "../hash-map-id" }

--- a/crates/lunatic-process/src/env.rs
+++ b/crates/lunatic-process/src/env.rs
@@ -28,10 +28,29 @@ impl Environment {
 
     pub fn add_process(&self, id: u64, proc: Arc<dyn Process>) {
         self.processes.insert(id, proc);
+        #[cfg(all(feature = "metrics", not(feature = "detailed_metrics")))]
+        let labels: [(String, String); 0] = [];
+        #[cfg(all(feature = "metrics", feature = "detailed_metrics"))]
+        let labels = [("environment_id", self.id().to_string())];
+
+        metrics::gauge!(
+            "lunatic.process.environment.process.count",
+            self.processes.len() as f64,
+            &labels
+        );
     }
 
     pub fn remove_process(&self, id: u64) {
         self.processes.remove(&id);
+        #[cfg(all(feature = "metrics", not(feature = "detailed_metrics")))]
+        let labels: [(String, String); 0] = [];
+        #[cfg(all(feature = "metrics", feature = "detailed_metrics"))]
+        let labels = [("environment_id", self.id().to_string())];
+        metrics::gauge!(
+            "lunatic.process.environment.process.count",
+            self.processes.len() as f64,
+            &labels
+        );
     }
 
     pub fn process_count(&self) -> usize {
@@ -63,6 +82,7 @@ impl Environments {
         if !self.envs.contains_key(&id) {
             let env = Environment::new(id);
             self.envs.insert(id, env.clone());
+            metrics::gauge!("lunatic.process.environment.count", self.envs.len() as f64);
             env
         } else {
             self.envs.get(&id).map(|e| e.clone()).unwrap()

--- a/crates/lunatic-process/src/lib.rs
+++ b/crates/lunatic-process/src/lib.rs
@@ -268,7 +268,7 @@ where
                         #[cfg(feature = "metrics")]
                         message.write_metrics();
 
-                        let res = message_mailbox.push(message);
+                        message_mailbox.push(message);
 
                         // process metrics
                         #[cfg(feature = "metrics")]
@@ -276,8 +276,6 @@ where
 
                         #[cfg(feature = "metrics")]
                         metrics::gauge!("lunatic.process.messages.outstanding", message_mailbox.len() as f64, &labels);
-
-                        res
                     },
                     Ok(Signal::DieWhenLinkDies(value)) => die_when_link_dies = value,
                     // Put process into list of linked processes

--- a/crates/lunatic-process/src/lib.rs
+++ b/crates/lunatic-process/src/lib.rs
@@ -22,6 +22,77 @@ use tokio::{
 
 use crate::{mailbox::MessageMailbox, message::Message};
 
+#[cfg(feature = "metrics")]
+pub fn describe_metrics() {
+    use metrics::{describe_counter, describe_gauge, describe_histogram, Unit};
+
+    describe_counter!(
+        "lunatic.process.signals.send",
+        Unit::Count,
+        "Number of signals sent to processes since startup"
+    );
+
+    describe_counter!(
+        "lunatic.process.signals.received",
+        Unit::Count,
+        "Number of signals received by processes since startup"
+    );
+
+    describe_counter!(
+        "lunatic.process.messages.send",
+        Unit::Count,
+        "Number of messages sent to processes since startup"
+    );
+
+    describe_gauge!(
+        "lunatic.process.messages.outstanding",
+        Unit::Count,
+        "Current number of messages that are ready to be consumed by the process"
+    );
+
+    describe_gauge!(
+        "lunatic.process.links.alive",
+        Unit::Count,
+        "Number of links currently alive"
+    );
+
+    describe_counter!(
+        "lunatic.process.messages.data.count",
+        Unit::Count,
+        "Number of data messages send since startup"
+    );
+
+    describe_histogram!(
+        "lunatic.process.messages.data.resources.count",
+        Unit::Count,
+        "Number of resources used by each individual data message"
+    );
+
+    describe_histogram!(
+        "lunatic.process.messages.data.size",
+        Unit::Bytes,
+        "Number of bytes used by each individual data message"
+    );
+
+    describe_counter!(
+        "lunatic.process.messages.link_died.count",
+        Unit::Count,
+        "Number of LinkDied messages send since startup"
+    );
+
+    describe_gauge!(
+        "lunatic.process.environment.process.count",
+        Unit::Count,
+        "Number of currently registered processes"
+    );
+
+    describe_gauge!(
+        "lunatic.process.environment.count",
+        Unit::Count,
+        "Number of currently active environments"
+    );
+}
+
 /// The `Process` is the main abstraction in lunatic.
 ///
 /// It usually represents some code that is being executed (Wasm instance or V8 isolate), but it
@@ -121,6 +192,16 @@ impl Process for WasmProcess {
         self.id
     }
     fn send(&self, signal: Signal) {
+        #[cfg(all(feature = "metrics", not(feature = "detailed_metrics")))]
+        let labels = [("process_kind", "wasm")];
+        #[cfg(all(feature = "metrics", feature = "detailed_metrics"))]
+        let labels = [
+            ("process_kind", "wasm"),
+            ("process_id", self.id().to_string()),
+        ];
+        #[cfg(feature = "metrics")]
+        metrics::increment_counter!("lunatic.process.signals.send", &labels);
+
         // If the receiver doesn't exist or is closed, just ignore it and drop the `signal`.
         // lunatic can't guarantee that a message was successfully seen by the receiving side even
         // if this call succeeds. We deliberately don't expose this API, as it would not make sense
@@ -169,24 +250,59 @@ where
     //       to protect against panics in host function calls that unwind through Wasm code.
     //       Currently a panic would just kill the task, but not notify linked processes.
     let mut signal_mailbox = signal_mailbox.lock().await;
+    #[cfg(all(feature = "metrics", not(feature = "detailed_metrics")))]
+    let labels: [(String, String); 0] = [];
+    #[cfg(all(feature = "metrics", feature = "detailed_metrics"))]
+    let labels = [("process_id", id.to_string())];
     let result = loop {
         tokio::select! {
             biased;
             // Handle signals first
             signal = signal_mailbox.recv() => {
+                #[cfg(feature = "metrics")]
+                metrics::increment_counter!("lunatic.process.signals.received", &labels);
+
                 match signal.ok_or(()) {
-                    Ok(Signal::Message(message)) => message_mailbox.push(message),
+                    Ok(Signal::Message(message)) => {
+
+                        #[cfg(feature = "metrics")]
+                        message.write_metrics();
+
+                        let res = message_mailbox.push(message);
+
+                        // process metrics
+                        #[cfg(feature = "metrics")]
+                        metrics::increment_counter!("lunatic.process.messages.send", &labels);
+
+                        #[cfg(feature = "metrics")]
+                        metrics::gauge!("lunatic.process.messages.outstanding", message_mailbox.len() as f64, &labels);
+
+                        res
+                    },
                     Ok(Signal::DieWhenLinkDies(value)) => die_when_link_dies = value,
                     // Put process into list of linked processes
-                    Ok(Signal::Link(tag, proc)) => { links.insert(proc.id(), (proc, tag)); },
+                    Ok(Signal::Link(tag, proc)) => {
+                        links.insert(proc.id(), (proc, tag));
+
+                        #[cfg(feature = "metrics")]
+                        metrics::gauge!("lunatic.process.links.alive", links.len() as f64, &labels);
+                    },
                     // Remove process from list
-                    Ok(Signal::UnLink { process_id }) => { links.remove(&process_id); }
+                    Ok(Signal::UnLink { process_id }) => {
+                        links.remove(&process_id);
+
+                        #[cfg(feature = "metrics")]
+                        metrics::gauge!("lunatic.process.links.alive", links.len() as f64, &labels);
+                    }
                     // Exit loop and don't poll anymore the future if Signal::Kill received.
                     Ok(Signal::Kill) => break Finished::KillSignal,
                     // Depending if `die_when_link_dies` is set, process will die or turn the
                     // signal into a message
                     Ok(Signal::LinkDied(id, tag, reason)) => {
                         links.remove(&id);
+
+                        #[cfg(feature = "metrics")]
+                        metrics::gauge!("lunatic.process.links.alive", links.len() as f64, &labels);
                         match reason {
                             DeathReason::Failure | DeathReason::NoProcess => {
                                 if die_when_link_dies {
@@ -195,6 +311,12 @@ where
                                     break Finished::KillSignal
                                 } else {
                                     let message = Message::LinkDied(tag);
+
+                                    #[cfg(feature = "metrics")]
+                                    metrics::increment_counter!("lunatic.process.messages.send", &labels);
+
+                                    #[cfg(feature = "metrics")]
+                                    metrics::gauge!("lunatic.process.messages.outstanding", message_mailbox.len() as f64, &labels);
                                     message_mailbox.push(message);
                                 }
                             },
@@ -304,6 +426,16 @@ impl Process for NativeProcess {
         self.id
     }
     fn send(&self, signal: Signal) {
+        #[cfg(all(feature = "metrics", not(feature = "detailed_metrics")))]
+        let labels = [("process_kind", "native")];
+        #[cfg(all(feature = "metrics", feature = "detailed_metrics"))]
+        let labels = [
+            ("process_kind", "native"),
+            ("process_id", self.id().to_string()),
+        ];
+        #[cfg(feature = "metrics")]
+        metrics::increment_counter!("lunatic.process.signals.send", &labels);
+
         // If the receiver doesn't exist or is closed, just ignore it and drop the `signal`.
         // lunatic can't guarantee that a message was successfully seen by the receiving side even
         // if this call succeeds. We deliberately don't expose this API, as it would not make sense

--- a/crates/lunatic-process/src/mailbox.rs
+++ b/crates/lunatic-process/src/mailbox.rs
@@ -139,11 +139,18 @@ impl MessageMailbox {
         mailbox.messages.push_back(message);
     }
 
-    /// Retrieves the number of messages currently available in the mailbox
+    /// Returns the number of messages currently available
     pub fn len(&self) -> usize {
         let mailbox = self.inner.lock().expect("only accessed by one process");
 
         mailbox.messages.len()
+    }
+
+    /// Returns true if the mailbox has no available messages
+    pub fn is_empty(&self) -> bool {
+        let mailbox = self.inner.lock().expect("only accessed by one process");
+
+        mailbox.messages.is_empty()
     }
 }
 

--- a/crates/lunatic-process/src/mailbox.rs
+++ b/crates/lunatic-process/src/mailbox.rs
@@ -138,6 +138,13 @@ impl MessageMailbox {
         // Otherwise put message into queue
         mailbox.messages.push_back(message);
     }
+
+    /// Retrieves the number of messages currently available in the mailbox
+    pub fn len(&self) -> usize {
+        let mailbox = self.inner.lock().expect("only accessed by one process");
+
+        mailbox.messages.len()
+    }
 }
 
 impl Future for &MessageMailbox {

--- a/crates/lunatic-process/src/message.rs
+++ b/crates/lunatic-process/src/message.rs
@@ -35,6 +35,16 @@ impl Message {
             Message::LinkDied(tag) => *tag,
         }
     }
+
+    #[cfg(feature = "metrics")]
+    pub fn write_metrics(&self) {
+        match self {
+            Message::Data(message) => message.write_metrics(),
+            Message::LinkDied(_) => {
+                metrics::increment_counter!("lunatic.process.messages.link_died.count");
+            }
+        }
+    }
 }
 
 /// A variant of a [`Message`] that has a buffer of data and resources attached to it.
@@ -155,6 +165,16 @@ impl DataMessage {
 
     pub fn size(&self) -> usize {
         self.buffer.len()
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn write_metrics(&self) {
+        metrics::increment_counter!("lunatic.process.messages.data.count");
+        metrics::histogram!(
+            "lunatic.process.messages.data.resources.count",
+            self.resources.len() as f64
+        );
+        metrics::histogram!("lunatic.process.messages.data.size", self.size() as f64);
     }
 }
 

--- a/crates/lunatic-registry-api/Cargo.toml
+++ b/crates/lunatic-registry-api/Cargo.toml
@@ -10,9 +10,13 @@ license = "Apache-2.0/MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+metrics = ["dep:metrics"]
+
 [dependencies]
 anyhow = "^1.0"
 wasmtime = "^0.40"
+metrics = { version = "0.20.1", optional = true }
 hash-map-id = { version = "^0.10", path = "../hash-map-id" }
 lunatic-process = { version = "^0.10", path = "../lunatic-process" }
 lunatic-process-api = { version = "^0.10", path = "../lunatic-process-api" }

--- a/crates/lunatic-timer-api/Cargo.toml
+++ b/crates/lunatic-timer-api/Cargo.toml
@@ -10,9 +10,13 @@ license = "Apache-2.0/MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+metrics = ["dep:metrics"]
+
 [dependencies]
 anyhow = "^1.0"
 wasmtime = "^0.40"
+metrics = { version = "0.20.1", optional = true }
 tokio = { version = "^1.20", features = ["rt", "time"] }
 hash-map-id = { version = "^0.10", path = "../hash-map-id" }
 lunatic-process = { version = "^0.10", path = "../lunatic-process" }

--- a/crates/lunatic-timer-api/src/lib.rs
+++ b/crates/lunatic-timer-api/src/lib.rs
@@ -147,7 +147,9 @@ fn send_after<T: ProcessState + ProcessCtx<T> + TimerCtx>(
             tokio::time::sleep(duration_remaining).await;
         }
         if let Some(process) = process {
+            #[cfg(feature = "metrics")]
             metrics::increment_counter!("lunatic.timers.completed");
+            #[cfg(feature = "metrics")]
             metrics::decrement_gauge!("lunatic.timers.active", 1.0);
             process.send(Signal::Message(message));
         }
@@ -177,7 +179,9 @@ fn cancel_timer<T: ProcessState + TimerCtx + Send>(
         match timer_handle {
             Some(timer_handle) => {
                 timer_handle.abort();
+                #[cfg(feature = "metrics")]
                 metrics::increment_counter!("lunatic.timers.canceled");
+                #[cfg(feature = "metrics")]
                 metrics::decrement_gauge!("lunatic.timers.active", 1.0);
                 Ok(1)
             }


### PR DESCRIPTION
This adds a variety of metrics to a bunch of methods, using the [metrics-rs](https://github.com/metrics-rs/metrics) crate.
According to the crate, as long as no recorder is installed, this has little performance impact.

All code is behind the "metrics" feature flag, but I have enabled it by default.
No recorder is included by default, but the "prometheus" feature flag adds the prometheus exporter, with appropriate CLI arguments.

I've tested this with [frenezulo](https://github.com/HurricanKai/frenezulo) and found the results to be quite useful already.
I plan to expose tokio metrics in the future & potentially allow WASM clients to expose their own metrics too, not sure yet.

[example prometheus output](https://github.com/lunatic-solutions/lunatic/files/9640804/sample.txt)

In my opinion the prometheus exporter could be included by default, but it should not be enabled (using `--prometheus` currently) if the user doesn't use it, as histograms appear to be tracked indefinitely, so if no one ever scrapes the prometheus output, it's memory usage will grow until the process is killed.