### PR TITLE
Fix windows builds on 1.64 stable and nightlies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,8 +303,7 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 [[package]]
 name = "cap-fs-ext"
 version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e142bbbe9d5d6a2dd0387f887a000b41f4c82fb1226316dfb4cc8dbc3b1a29"
+source = "git+https://github.com/bytecodealliance/cap-std.git?branch=0.26-with-a-0.25.2-version-number#90e115e1ad21392a9601357da639b9fccbd25dab"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -315,11 +314,9 @@ dependencies = [
 [[package]]
 name = "cap-primitives"
 version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f22f4975282dd4f2330ee004f001c4e22f420da9fb474ea600e9af330f1e548"
+source = "git+https://github.com/bytecodealliance/cap-std.git?branch=0.26-with-a-0.25.2-version-number#90e115e1ad21392a9601357da639b9fccbd25dab"
 dependencies = [
  "ambient-authority",
- "errno",
  "fs-set-times",
  "io-extras",
  "io-lifetimes",
@@ -344,8 +341,7 @@ dependencies = [
 [[package]]
 name = "cap-std"
 version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95624bb0abba6b6ff6fad2e02a7d3945d093d064ac5a3477a308c29fbe3bfd49"
+source = "git+https://github.com/bytecodealliance/cap-std.git?branch=0.26-with-a-0.25.2-version-number#90e115e1ad21392a9601357da639b9fccbd25dab"
 dependencies = [
  "cap-primitives",
  "io-extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,12 @@ members = [
     "crates/lunatic-registry-api",
     "crates/lunatic-distributed-api",
 ]
+
+##########################################################
+# This is required until wasmtime is bumped to ^1
+# https://github.com/bytecodealliance/wasmtime/issues/4936
+# Tracking: https://github.com/lunatic-solutions/lunatic/issues/136
+[patch.crates-io]
+cap-std = { git = "https://github.com/bytecodealliance/cap-std.git", branch = "0.26-with-a-0.25.2-version-number" }
+cap-primitives = { git = "https://github.com/bytecodealliance/cap-std.git", branch = "0.26-with-a-0.25.2-version-number" }
+cap-fs-ext = { git = "https://github.com/bytecodealliance/cap-std.git", branch = "0.26-with-a-0.25.2-version-number" }


### PR DESCRIPTION
Fixes #136 

We need to bump wasmtime to ^1 but in the meantime this is a patch-fix which will use overrides to three crates that broke from associated std changes that changed a trait to sealed as I've documented in https://github.com/rust-lang/rust/issues/102260

Somehow it was not replicated on 1.64 stable on Windows - nightly did repro this - but I have to test more.