### PR TITLE
Abstract Environments

### DIFF
--- a/crates/lunatic-distributed/src/distributed/server.rs
+++ b/crates/lunatic-distributed/src/distributed/server.rs
@@ -3,7 +3,7 @@ use std::{net::SocketAddr, sync::Arc};
 use anyhow::{anyhow, Result};
 
 use lunatic_process::{
-    env::Environments,
+    env::{Environment, Environments},
     message::{DataMessage, Message},
     runtimes::{wasmtime::WasmtimeRuntime, Modules, RawWasm},
     state::ProcessState,
@@ -19,14 +19,14 @@ use crate::{
 
 use super::message::Spawn;
 
-pub struct ServerCtx<T> {
-    pub envs: Arc<dyn Environments>,
+pub struct ServerCtx<T, E: Environment> {
+    pub envs: Arc<dyn Environments<Env = E>>,
     pub modules: Modules<T>,
     pub distributed: DistributedProcessState,
     pub runtime: WasmtimeRuntime,
 }
 
-impl<T: 'static> Clone for ServerCtx<T> {
+impl<T: 'static, E: Environment> Clone for ServerCtx<T, E> {
     fn clone(&self) -> Self {
         Self {
             envs: self.envs.clone(),
@@ -58,37 +58,44 @@ pub fn gen_node_cert(node_name: &str) -> Result<Certificate> {
         .map_err(|_| anyhow!("Error while generating node certificate."))
 }
 
-pub async fn node_server<T>(
-    ctx: ServerCtx<T>,
+pub async fn node_server<T, E>(
+    ctx: ServerCtx<T, E>,
     socket: SocketAddr,
     cert: String,
     key: String,
 ) -> Result<()>
 where
-    T: ProcessState + ResourceLimiter + DistributedCtx + Send + 'static,
+    T: ProcessState + ResourceLimiter + DistributedCtx<E> + Send + 'static,
+    E: Environment + 'static,
 {
     let mut quic_server = quic::new_quic_server(socket, &cert, &key)?;
     quic::handle_node_server(&mut quic_server, ctx.clone()).await?;
     Ok(())
 }
 
-pub async fn handle_message<T>(ctx: ServerCtx<T>, conn: quic::Connection, msg_id: u64, msg: Request)
-where
-    T: ProcessState + DistributedCtx + ResourceLimiter + Send + 'static,
+pub async fn handle_message<T, E>(
+    ctx: ServerCtx<T, E>,
+    conn: quic::Connection,
+    msg_id: u64,
+    msg: Request,
+) where
+    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + 'static,
+    E: Environment + 'static,
 {
     if let Err(e) = handle_message_err(ctx, conn, msg_id, msg).await {
         log::error!("Error handling message: {e}");
     }
 }
 
-async fn handle_message_err<T>(
-    ctx: ServerCtx<T>,
+async fn handle_message_err<T, E>(
+    ctx: ServerCtx<T, E>,
     conn: quic::Connection,
     msg_id: u64,
     msg: Request,
 ) -> Result<()>
 where
-    T: ProcessState + DistributedCtx + ResourceLimiter + Send + 'static,
+    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + 'static,
+    E: Environment + 'static,
 {
     match msg {
         Request::Spawn(spawn) => {
@@ -105,9 +112,10 @@ where
     Ok(())
 }
 
-async fn handle_spawn<T>(ctx: ServerCtx<T>, spawn: Spawn) -> Result<u64>
+async fn handle_spawn<T, E>(ctx: ServerCtx<T, E>, spawn: Spawn) -> Result<u64>
 where
-    T: ProcessState + DistributedCtx + ResourceLimiter + Send + 'static,
+    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + 'static,
+    E: Environment + 'static,
 {
     let Spawn {
         environment_id,
@@ -150,15 +158,16 @@ where
     Ok(proc.id())
 }
 
-async fn handle_process_message<T>(
-    ctx: ServerCtx<T>,
+async fn handle_process_message<T, E>(
+    ctx: ServerCtx<T, E>,
     environment_id: u64,
     process_id: u64,
     tag: Option<i64>,
     data: Vec<u8>,
 ) -> Result<()>
 where
-    T: ProcessState + DistributedCtx + ResourceLimiter + Send + 'static,
+    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + 'static,
+    E: Environment,
 {
     let env = ctx.envs.get_or_create(environment_id);
     if let Some(proc) = env.get_process(process_id) {

--- a/crates/lunatic-distributed/src/distributed/server.rs
+++ b/crates/lunatic-distributed/src/distributed/server.rs
@@ -140,7 +140,10 @@ where
         }
     };
 
-    let env = ctx.envs.get_or_create(environment_id);
+    let env = ctx
+        .envs
+        .get(environment_id)
+        .unwrap_or(ctx.envs.create(environment_id));
     let distributed = ctx.distributed.clone();
     let runtime = ctx.runtime.clone();
     let state = T::new_dist_state(env.clone(), distributed, runtime, module.clone(), config)?;
@@ -169,11 +172,13 @@ where
     T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + 'static,
     E: Environment,
 {
-    let env = ctx.envs.get_or_create(environment_id);
-    if let Some(proc) = env.get_process(process_id) {
-        proc.send(Signal::Message(Message::Data(DataMessage::new_from_vec(
-            tag, data,
-        ))))
+    let env = ctx.envs.get(environment_id);
+    if let Some(env) = env {
+        if let Some(proc) = env.get_process(process_id) {
+            proc.send(Signal::Message(Message::Data(DataMessage::new_from_vec(
+                tag, data,
+            ))))
+        }
     }
     Ok(())
 }

--- a/crates/lunatic-distributed/src/distributed/server.rs
+++ b/crates/lunatic-distributed/src/distributed/server.rs
@@ -20,7 +20,7 @@ use crate::{
 use super::message::Spawn;
 
 pub struct ServerCtx<T> {
-    pub envs: Environments,
+    pub envs: Arc<dyn Environments>,
     pub modules: Modules<T>,
     pub distributed: DistributedProcessState,
     pub runtime: WasmtimeRuntime,
@@ -105,7 +105,7 @@ where
     Ok(())
 }
 
-async fn handle_spawn<T>(mut ctx: ServerCtx<T>, spawn: Spawn) -> Result<u64>
+async fn handle_spawn<T>(ctx: ServerCtx<T>, spawn: Spawn) -> Result<u64>
 where
     T: ProcessState + DistributedCtx + ResourceLimiter + Send + 'static,
 {
@@ -151,7 +151,7 @@ where
 }
 
 async fn handle_process_message<T>(
-    mut ctx: ServerCtx<T>,
+    ctx: ServerCtx<T>,
     environment_id: u64,
     process_id: u64,
     tag: Option<i64>,

--- a/crates/lunatic-distributed/src/distributed/server.rs
+++ b/crates/lunatic-distributed/src/distributed/server.rs
@@ -137,9 +137,16 @@ where
     let runtime = ctx.runtime.clone();
     let state = T::new_dist_state(env.clone(), distributed, runtime, module.clone(), config)?;
     let params: Vec<wasmtime::Val> = params.into_iter().map(Into::into).collect();
-    let (_handle, proc) = env
-        .spawn_wasm(ctx.runtime, &module, state, &function, params, None)
-        .await?;
+    let (_handle, proc) = lunatic_process::wasm::spawn_wasm(
+        env,
+        ctx.runtime,
+        &module,
+        state,
+        &function,
+        params,
+        None,
+    )
+    .await?;
     Ok(proc.id())
 }
 

--- a/crates/lunatic-distributed/src/distributed/server.rs
+++ b/crates/lunatic-distributed/src/distributed/server.rs
@@ -143,7 +143,7 @@ where
     let env = ctx
         .envs
         .get(environment_id)
-        .unwrap_or(ctx.envs.create(environment_id));
+        .unwrap_or_else(|| ctx.envs.create(environment_id));
     let distributed = ctx.distributed.clone();
     let runtime = ctx.runtime.clone();
     let state = T::new_dist_state(env.clone(), distributed, runtime, module.clone(), config)?;

--- a/crates/lunatic-distributed/src/lib.rs
+++ b/crates/lunatic-distributed/src/lib.rs
@@ -10,9 +10,9 @@ use lunatic_process::{
 };
 use std::{net::SocketAddr, sync::Arc};
 
-pub trait DistributedCtx: ProcessState + Sized {
+pub trait DistributedCtx<E: Environment>: ProcessState + Sized {
     fn new_dist_state(
-        environment: Arc<dyn Environment>,
+        environment: Arc<E>,
         distributed: DistributedProcessState,
         runtime: WasmtimeRuntime,
         module: Arc<WasmtimeCompiledModule<Self>>,

--- a/crates/lunatic-distributed/src/lib.rs
+++ b/crates/lunatic-distributed/src/lib.rs
@@ -12,7 +12,7 @@ use std::{net::SocketAddr, sync::Arc};
 
 pub trait DistributedCtx: ProcessState + Sized {
     fn new_dist_state(
-        environment: Environment,
+        environment: Arc<dyn Environment>,
         distributed: DistributedProcessState,
         runtime: WasmtimeRuntime,
         module: Arc<WasmtimeCompiledModule<Self>>,

--- a/crates/lunatic-networking-api/src/lib.rs
+++ b/crates/lunatic-networking-api/src/lib.rs
@@ -124,7 +124,7 @@ fn socket_address<T: NetworkingCtx>(
     Ok(match addr_type {
         4 => {
             let ip = memory
-                .data(&caller)
+                .data(caller)
                 .get(addr_u8_ptr as usize..(addr_u8_ptr + 4) as usize)
                 .or_trap("lunatic::network::socket_address*")?;
             let addr = <Ipv4Addr as From<[u8; 4]>>::from(ip.try_into().expect("exactly 4 bytes"));
@@ -132,7 +132,7 @@ fn socket_address<T: NetworkingCtx>(
         }
         6 => {
             let ip = memory
-                .data(&caller)
+                .data(caller)
                 .get(addr_u8_ptr as usize..(addr_u8_ptr + 16) as usize)
                 .or_trap("lunatic::network::socket_address*")?;
             let addr = <Ipv6Addr as From<[u8; 16]>>::from(ip.try_into().expect("exactly 16 bytes"));

--- a/crates/lunatic-process/src/env.rs
+++ b/crates/lunatic-process/src/env.rs
@@ -6,14 +6,24 @@ use std::sync::{
 
 use crate::{Process, Signal};
 
+pub trait Environment: Send + Sync {
+    fn id(&self) -> u64;
+    fn get_next_process_id(&self) -> u64;
+    fn get_process(&self, id: u64) -> Option<Arc<dyn Process>>;
+    fn add_process(&self, id: u64, proc: Arc<dyn Process>);
+    fn remove_process(&self, id: u64);
+    fn process_count(&self) -> usize;
+    fn send(&self, id: u64, signal: Signal);
+}
+
 #[derive(Clone)]
-pub struct Environment {
+pub struct LunaticEnvironment {
     environment_id: u64,
     next_process_id: Arc<AtomicU64>,
     processes: Arc<DashMap<u64, Arc<dyn Process>>>,
 }
 
-impl Environment {
+impl LunaticEnvironment {
     pub fn new(id: u64) -> Self {
         Self {
             environment_id: id,
@@ -21,12 +31,14 @@ impl Environment {
             next_process_id: Arc::new(AtomicU64::new(1)),
         }
     }
+}
 
-    pub fn get_process(&self, id: u64) -> Option<Arc<dyn Process>> {
+impl Environment for LunaticEnvironment {
+    fn get_process(&self, id: u64) -> Option<Arc<dyn Process>> {
         self.processes.get(&id).map(|x| x.clone())
     }
 
-    pub fn add_process(&self, id: u64, proc: Arc<dyn Process>) {
+    fn add_process(&self, id: u64, proc: Arc<dyn Process>) {
         self.processes.insert(id, proc);
         #[cfg(all(feature = "metrics", not(feature = "detailed_metrics")))]
         let labels: [(String, String); 0] = [];
@@ -40,7 +52,7 @@ impl Environment {
         );
     }
 
-    pub fn remove_process(&self, id: u64) {
+    fn remove_process(&self, id: u64) {
         self.processes.remove(&id);
         #[cfg(all(feature = "metrics", not(feature = "detailed_metrics")))]
         let labels: [(String, String); 0] = [];
@@ -53,34 +65,34 @@ impl Environment {
         );
     }
 
-    pub fn process_count(&self) -> usize {
+    fn process_count(&self) -> usize {
         self.processes.len()
     }
 
-    pub fn send(&self, id: u64, signal: Signal) {
+    fn send(&self, id: u64, signal: Signal) {
         if let Some(proc) = self.processes.get(&id) {
             proc.send(signal);
         }
     }
 
-    pub fn get_next_process_id(&self) -> u64 {
+    fn get_next_process_id(&self) -> u64 {
         self.next_process_id.fetch_add(1, Ordering::Relaxed)
     }
 
-    pub fn id(&self) -> u64 {
+    fn id(&self) -> u64 {
         self.environment_id
     }
 }
 
 #[derive(Clone, Default)]
 pub struct Environments {
-    envs: Arc<DashMap<u64, Environment>>,
+    envs: Arc<DashMap<u64, Arc<dyn Environment>>>,
 }
 
 impl Environments {
-    pub fn get_or_create(&mut self, id: u64) -> Environment {
+    pub fn get_or_create(&mut self, id: u64) -> Arc<dyn Environment> {
         if !self.envs.contains_key(&id) {
-            let env = Environment::new(id);
+            let env = Arc::new(LunaticEnvironment::new(id));
             self.envs.insert(id, env.clone());
             metrics::gauge!("lunatic.process.environment.count", self.envs.len() as f64);
             env

--- a/crates/lunatic-process/src/env.rs
+++ b/crates/lunatic-process/src/env.rs
@@ -16,6 +16,10 @@ pub trait Environment: Send + Sync {
     fn send(&self, id: u64, signal: Signal);
 }
 
+pub trait Environments: Send + Sync {
+    fn get_or_create(&self, id: u64) -> Arc<dyn Environment>;
+}
+
 #[derive(Clone)]
 pub struct LunaticEnvironment {
     environment_id: u64,
@@ -85,12 +89,12 @@ impl Environment for LunaticEnvironment {
 }
 
 #[derive(Clone, Default)]
-pub struct Environments {
+pub struct LunaticEnvironments {
     envs: Arc<DashMap<u64, Arc<dyn Environment>>>,
 }
 
-impl Environments {
-    pub fn get_or_create(&mut self, id: u64) -> Arc<dyn Environment> {
+impl Environments for LunaticEnvironments {
+    fn get_or_create(&self, id: u64) -> Arc<dyn Environment> {
         if !self.envs.contains_key(&id) {
             let env = Arc::new(LunaticEnvironment::new(id));
             self.envs.insert(id, env.clone());

--- a/crates/lunatic-process/src/env.rs
+++ b/crates/lunatic-process/src/env.rs
@@ -17,7 +17,8 @@ pub trait Environment: Send + Sync {
 }
 
 pub trait Environments: Send + Sync {
-    fn get_or_create(&self, id: u64) -> Arc<dyn Environment>;
+    type Env: Environment;
+    fn get_or_create(&self, id: u64) -> Arc<Self::Env>;
 }
 
 #[derive(Clone)]
@@ -90,11 +91,12 @@ impl Environment for LunaticEnvironment {
 
 #[derive(Clone, Default)]
 pub struct LunaticEnvironments {
-    envs: Arc<DashMap<u64, Arc<dyn Environment>>>,
+    envs: Arc<DashMap<u64, Arc<LunaticEnvironment>>>,
 }
 
 impl Environments for LunaticEnvironments {
-    fn get_or_create(&self, id: u64) -> Arc<dyn Environment> {
+    type Env = LunaticEnvironment;
+    fn get_or_create(&self, id: u64) -> Arc<Self::Env> {
         if !self.envs.contains_key(&id) {
             let env = Arc::new(LunaticEnvironment::new(id));
             self.envs.insert(id, env.clone());

--- a/crates/lunatic-process/src/wasm.rs
+++ b/crates/lunatic-process/src/wasm.rs
@@ -19,70 +19,68 @@ use crate::{Process, Signal, WasmProcess};
 /// After it's spawned the process will keep running in the background. A process can be killed
 /// with `Signal::Kill` signal. If you would like to block until the process is finished you can
 /// `.await` on the returned `JoinHandle<()>`.
-impl Environment {
-    pub async fn spawn_wasm<S>(
-        &self,
-        runtime: WasmtimeRuntime,
-        module: &WasmtimeCompiledModule<S>,
-        state: S,
-        function: &str,
-        params: Vec<Val>,
-        link: Option<(Option<i64>, Arc<dyn Process>)>,
-    ) -> Result<(JoinHandle<Result<S>>, Arc<dyn Process>)>
-    where
-        S: ProcessState + Send + ResourceLimiter + 'static,
-    {
-        let id = state.id();
-        trace!("Spawning process: {}", id);
-        let signal_mailbox = state.signal_mailbox().clone();
-        let message_mailbox = state.message_mailbox().clone();
+pub async fn spawn_wasm<S>(
+    env: Arc<dyn Environment>,
+    runtime: WasmtimeRuntime,
+    module: &WasmtimeCompiledModule<S>,
+    state: S,
+    function: &str,
+    params: Vec<Val>,
+    link: Option<(Option<i64>, Arc<dyn Process>)>,
+) -> Result<(JoinHandle<Result<S>>, Arc<dyn Process>)>
+where
+    S: ProcessState + Send + ResourceLimiter + 'static,
+{
+    let id = state.id();
+    trace!("Spawning process: {}", id);
+    let signal_mailbox = state.signal_mailbox().clone();
+    let message_mailbox = state.message_mailbox().clone();
 
-        let instance = runtime.instantiate(module, state).await?;
-        let function = function.to_string();
-        let fut = async move { instance.call(&function, params).await };
-        let child_process = crate::new(fut, id, self.clone(), signal_mailbox.1, message_mailbox);
-        let child_process_handle = Arc::new(WasmProcess::new(id, signal_mailbox.0.clone()));
+    let instance = runtime.instantiate(module, state).await?;
+    let function = function.to_string();
+    let fut = async move { instance.call(&function, params).await };
+    let child_process = crate::new(fut, id, env.clone(), signal_mailbox.1, message_mailbox);
+    let child_process_handle = Arc::new(WasmProcess::new(id, signal_mailbox.0.clone()));
 
-        self.add_process(id, child_process_handle.clone());
+    env.add_process(id, child_process_handle.clone());
 
-        // **Child link guarantees**:
-        // The link signal is going to be put inside of the child's mailbox and is going to be
-        // processed before any child code can run. This means that any failure inside the child
-        // Wasm code will be correctly reported to the parent.
-        //
-        // We assume here that the code inside of `process::new()` will not fail during signal
-        // handling.
-        //
-        // **Parent link guarantees**:
-        // A `tokio::task::yield_now()` call is executed to allow the parent to link the child
-        // before continuing any further execution. This should force the parent to process all
-        // signals right away.
-        //
-        // The parent could have received a `kill` signal in its mailbox before this function was
-        // called and this signal is going to be processed before the link is established (FIFO).
-        // Only after the yield function we can guarantee that the child is going to be notified
-        // if the parent fails. This is ok, as the actual spawning of the child happens after the
-        // call, so the child wouldn't even exist if the parent failed before.
-        //
-        // TODO: The guarantees provided here don't hold anymore in a distributed environment and
-        //       will require some rethinking. This function will be executed on a completely
-        //       different computer and needs to be synced in a more robust way with the parent
-        //       running somewhere else.
-        if let Some((tag, process)) = link {
-            // Send signal to itself to perform the linking
-            process.send(Signal::Link(None, child_process_handle.clone()));
-            // Suspend itself to process all new signals
-            tokio::task::yield_now().await;
-            // Send signal to child to link it
-            signal_mailbox
-                .0
-                .send(Signal::Link(tag, process))
-                .expect("receiver must exist at this point");
-        }
-
-        // Spawn a background process
-        trace!("Process size: {}", std::mem::size_of_val(&child_process));
-        let join = tokio::task::spawn(child_process);
-        Ok((join, child_process_handle))
+    // **Child link guarantees**:
+    // The link signal is going to be put inside of the child's mailbox and is going to be
+    // processed before any child code can run. This means that any failure inside the child
+    // Wasm code will be correctly reported to the parent.
+    //
+    // We assume here that the code inside of `process::new()` will not fail during signal
+    // handling.
+    //
+    // **Parent link guarantees**:
+    // A `tokio::task::yield_now()` call is executed to allow the parent to link the child
+    // before continuing any further execution. This should force the parent to process all
+    // signals right away.
+    //
+    // The parent could have received a `kill` signal in its mailbox before this function was
+    // called and this signal is going to be processed before the link is established (FIFO).
+    // Only after the yield function we can guarantee that the child is going to be notified
+    // if the parent fails. This is ok, as the actual spawning of the child happens after the
+    // call, so the child wouldn't even exist if the parent failed before.
+    //
+    // TODO: The guarantees provided here don't hold anymore in a distributed environment and
+    //       will require some rethinking. This function will be executed on a completely
+    //       different computer and needs to be synced in a more robust way with the parent
+    //       running somewhere else.
+    if let Some((tag, process)) = link {
+        // Send signal to itself to perform the linking
+        process.send(Signal::Link(None, child_process_handle.clone()));
+        // Suspend itself to process all new signals
+        tokio::task::yield_now().await;
+        // Send signal to child to link it
+        signal_mailbox
+            .0
+            .send(Signal::Link(tag, process))
+            .expect("receiver must exist at this point");
     }
+
+    // Spawn a background process
+    trace!("Process size: {}", std::mem::size_of_val(&child_process));
+    let join = tokio::task::spawn(child_process);
+    Ok((join, child_process_handle))
 }

--- a/src/mode/cargo_test.rs
+++ b/src/mode/cargo_test.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use clap::{crate_version, Arg, Command};
 
 use dashmap::DashMap;
-use lunatic_process::{env::Environment, runtimes};
+use lunatic_process::{env::LunaticEnvironment, runtimes, wasm::spawn_wasm};
 use lunatic_process_api::ProcessConfigCtx;
 use lunatic_runtime::{DefaultProcessConfig, DefaultProcessState};
 use lunatic_stdout_capture::StdoutCapture;
@@ -253,7 +253,7 @@ pub(crate) async fn test() -> Result<()> {
             continue;
         }
 
-        let env = Environment::new(0);
+        let env = Arc::new(LunaticEnvironment::new(0));
         let registry = Arc::new(DashMap::new());
         let mut state = DefaultProcessState::new(
             env.clone(),
@@ -272,21 +272,21 @@ pub(crate) async fn test() -> Result<()> {
         state.set_stdout(stdout.clone());
         state.set_stderr(stdout.clone());
 
-        let (task, _) = env
-            .spawn_wasm(
-                runtime.clone(),
-                &module,
-                state,
-                &test_function.wasm_export_name,
-                Vec::new(),
-                None,
-            )
-            .await
-            .context(format!(
-                "Failed to spawn process from {}::{}",
-                path.to_string_lossy(),
-                test_function.function_name
-            ))?;
+        let (task, _) = spawn_wasm(
+            env,
+            runtime.clone(),
+            &module,
+            state,
+            &test_function.wasm_export_name,
+            Vec::new(),
+            None,
+        )
+        .await
+        .context(format!(
+            "Failed to spawn process from {}::{}",
+            path.to_string_lossy(),
+            test_function.function_name
+        ))?;
 
         let sender = sender.clone();
         tokio::task::spawn(async move {

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -12,6 +12,7 @@ use lunatic_distributed::{
 use lunatic_process::{
     env::Environments,
     runtimes::{self, Modules, RawWasm},
+    wasm::spawn_wasm,
 };
 use lunatic_process_api::ProcessConfigCtx;
 use lunatic_runtime::{DefaultProcessConfig, DefaultProcessState};
@@ -274,8 +275,7 @@ pub(crate) async fn execute() -> Result<()> {
         )
         .unwrap();
 
-        let (task, _) = env
-            .spawn_wasm(runtime, &module, state, "_start", Vec::new(), None)
+        let (task, _) = spawn_wasm(env, runtime, &module, state, "_start", Vec::new(), None)
             .await
             .context(format!(
                 "Failed to spawn process from {}::_start()",

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -10,7 +10,7 @@ use lunatic_distributed::{
     quic,
 };
 use lunatic_process::{
-    env::Environments,
+    env::{Environments, LunaticEnvironments},
     runtimes::{self, Modules, RawWasm},
     wasm::spawn_wasm,
 };
@@ -143,7 +143,7 @@ pub(crate) async fn execute() -> Result<()> {
     // Create wasmtime runtime
     let wasmtime_config = runtimes::wasmtime::default_config();
     let runtime = runtimes::wasmtime::WasmtimeRuntime::new(&wasmtime_config)?;
-    let mut envs = Environments::default();
+    let envs = Arc::new(LunaticEnvironments::default());
 
     let env = envs.get_or_create(1);
 

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -145,7 +145,7 @@ pub(crate) async fn execute() -> Result<()> {
     let runtime = runtimes::wasmtime::WasmtimeRuntime::new(&wasmtime_config)?;
     let envs = Arc::new(LunaticEnvironments::default());
 
-    let env = envs.get_or_create(1);
+    let env = envs.create(1);
 
     let (distributed_state, control_client, node_id) =
         if let (Some(node_address), Some(control_address)) =

--- a/src/state.rs
+++ b/src/state.rs
@@ -31,7 +31,7 @@ use crate::DefaultProcessConfig;
 pub struct DefaultProcessState {
     // Process id
     pub(crate) id: u64,
-    pub(crate) environment: Arc<dyn Environment>,
+    pub(crate) environment: Arc<LunaticEnvironment>,
     pub(crate) distributed: Option<DistributedProcessState>,
     // The WebAssembly runtime
     runtime: Option<WasmtimeRuntime>,
@@ -65,7 +65,7 @@ pub struct DefaultProcessState {
 
 impl DefaultProcessState {
     pub fn new(
-        environment: Arc<dyn Environment>,
+        environment: Arc<LunaticEnvironment>,
         distributed: Option<DistributedProcessState>,
         runtime: WasmtimeRuntime,
         module: Arc<WasmtimeCompiledModule<Self>>,
@@ -396,7 +396,7 @@ pub(crate) struct Resources {
     pub(crate) errors: HashMapId<anyhow::Error>,
 }
 
-impl DistributedCtx for DefaultProcessState {
+impl DistributedCtx<LunaticEnvironment> for DefaultProcessState {
     fn distributed_mut(&mut self) -> Result<&mut DistributedProcessState> {
         match self.distributed.as_mut() {
             Some(d) => Ok(d),
@@ -427,7 +427,7 @@ impl DistributedCtx for DefaultProcessState {
     }
 
     fn new_dist_state(
-        environment: Arc<dyn Environment>,
+        environment: Arc<LunaticEnvironment>,
         distributed: DistributedProcessState,
         runtime: WasmtimeRuntime,
         module: Arc<WasmtimeCompiledModule<Self>>,


### PR DESCRIPTION
This PR changes `Environment` and `Environments` into a trait.

This abstraction is useful when using `lunatic` as an library when embedding into another application,
similar to `Process` and `ProcessState` abstractions.