### PR TITLE
Implement a Stacked Scratch Area

### DIFF
--- a/crates/lunatic-distributed-api/src/lib.rs
+++ b/crates/lunatic-distributed-api/src/lib.rs
@@ -215,9 +215,7 @@ where
             .message_scratch_area()
             .take()
             .or_trap("lunatic::message::send::no_message")?;
-        let message = stack 
-            .pop()
-            .or_trap("lunatic::message::send::no_message")?;
+        let message = stack.pop().or_trap("lunatic::message::send::no_message")?;
 
         if let Message::Data(DataMessage {
             tag,
@@ -280,9 +278,7 @@ where
             .take()
             .or_trap("lunatic::message::send::no_message")?;
 
-        let message = stack
-            .pop()
-            .or_trap("lunatic::message::send::no_message")?;
+        let message = stack.pop().or_trap("lunatic::message::send::no_message")?;
 
         let mut _tags = [0; 1];
         let tags = if let Some(tag) = message.tag() {

--- a/crates/lunatic-messaging-api/src/lib.rs
+++ b/crates/lunatic-messaging-api/src/lib.rs
@@ -138,7 +138,7 @@ fn create_data<T: ProcessState + ProcessCtx<T>>(
         .message_scratch_area()
         .take()
         .or_trap("lunatic::message::create_data")?;
-    
+
     stack.push(Message::Data(message));
 
     caller.data_mut().message_scratch_area().replace(stack);
@@ -156,7 +156,7 @@ fn write_data<T: ProcessState + ProcessCtx<T>>(
     data_len: u32,
 ) -> Result<u32, Trap> {
     let memory = get_memory(&mut caller)?;
-    
+
     let mut stack = caller
         .data_mut()
         .message_scratch_area()
@@ -168,10 +168,7 @@ fn write_data<T: ProcessState + ProcessCtx<T>>(
         .get(data_ptr as usize..(data_ptr as usize + data_len as usize))
         .or_trap("lunatic::message::write_data")?;
 
-
-    let mut message = stack
-        .last_mut()
-        .or_trap("lunatic::message::write_data")?;
+    let mut message = stack.last_mut().or_trap("lunatic::message::write_data")?;
 
     let bytes = match &mut message {
         Message::Data(data) => data.write(buffer).or_trap("lunatic::message::write_data")?,
@@ -194,7 +191,6 @@ fn read_data<T: ProcessState + ProcessCtx<T>>(
     data_ptr: u32,
     data_len: u32,
 ) -> Result<u32, Trap> {
-
     let memory = get_memory(&mut caller)?;
     let mut stack = caller
         .data_mut()
@@ -202,9 +198,7 @@ fn read_data<T: ProcessState + ProcessCtx<T>>(
         .take()
         .or_trap("lunatic::message::read_data")?;
 
-    let mut message = stack
-        .last_mut()
-        .or_trap("lunatic::message::read_data")?;
+    let mut message = stack.last_mut().or_trap("lunatic::message::read_data")?;
 
     let buffer = memory
         .data_mut(&mut caller)
@@ -238,9 +232,7 @@ fn seek_data<T: ProcessState + ProcessCtx<T>>(
         .take()
         .or_trap("lunatic::message::seek_data")?;
 
-    let mut message = stack
-        .last_mut()
-        .or_trap("lunatic::message::seek_data")?;
+    let mut message = stack.last_mut().or_trap("lunatic::message::seek_data")?;
     match &mut message {
         Message::Data(data) => data.seek(index as usize),
         Message::LinkDied(_) => {
@@ -319,10 +311,8 @@ fn push_module<T: ProcessState + ProcessCtx<T> + NetworkingCtx + 'static>(
         .message_scratch_area()
         .take()
         .or_trap("lunatic::message::push_module")?;
-    
-    let message = stack
-        .last_mut()
-        .or_trap("lunatic::message::push_module")?;
+
+    let message = stack.last_mut().or_trap("lunatic::message::push_module")?;
 
     let index = match message {
         Message::Data(data) => data.add_resource(module) as u64,
@@ -440,7 +430,7 @@ fn push_tls_stream<T: ProcessState + ProcessCtx<T> + NetworkingCtx>(
         .remove(stream_id)
         .or_trap("lunatic::message::push_tls_stream")?;
 
-    let mut stack  = caller
+    let mut stack = caller
         .data_mut()
         .message_scratch_area()
         .take()
@@ -504,9 +494,7 @@ fn send<T: ProcessState + ProcessCtx<T>>(
         .take()
         .or_trap("lunatic::message::send::no_message")?;
 
-    let message = stack
-        .pop()
-        .or_trap("lunatic::message::send::no_message")?;
+    let message = stack.pop().or_trap("lunatic::message::send::no_message")?;
 
     if let Some(process) = caller.data_mut().environment().get_process(process_id) {
         process.send(Signal::Message(message));

--- a/crates/lunatic-process-api/src/lib.rs
+++ b/crates/lunatic-process-api/src/lib.rs
@@ -35,7 +35,8 @@ pub trait ProcessConfigCtx {
 
 pub trait ProcessCtx<S: ProcessState> {
     fn mailbox(&mut self) -> &mut MessageMailbox;
-    fn message_scratch_area(&mut self) -> &mut Option<Message>;
+    fn message_scratch_area(&mut self) -> &mut Option<Vec<Message>>;
+    fn message_receive_area(&mut self) -> &mut Option<Message>;
     fn module_resources(&self) -> &ModuleResources<S>;
     fn module_resources_mut(&mut self) -> &mut ModuleResources<S>;
     fn environment(&self) -> Arc<dyn Environment>;

--- a/crates/lunatic-timer-api/src/lib.rs
+++ b/crates/lunatic-timer-api/src/lib.rs
@@ -136,9 +136,7 @@ fn send_after<T: ProcessState + ProcessCtx<T> + TimerCtx>(
         .take()
         .or_trap("lunatic::message::send_after")?;
 
-    let message = stack
-        .pop()
-        .or_trap("lunatic::message::send_after")?;
+    let message = stack.pop().or_trap("lunatic::message::send_after")?;
 
     caller.data_mut().message_scratch_area().replace(stack);
 

--- a/crates/lunatic-timer-api/src/lib.rs
+++ b/crates/lunatic-timer-api/src/lib.rs
@@ -130,11 +130,17 @@ fn send_after<T: ProcessState + ProcessCtx<T> + TimerCtx>(
     process_id: u64,
     delay: u64,
 ) -> Result<u64, Trap> {
-    let message = caller
+    let mut stack = caller
         .data_mut()
         .message_scratch_area()
         .take()
         .or_trap("lunatic::message::send_after")?;
+
+    let message = stack
+        .pop()
+        .or_trap("lunatic::message::send_after")?;
+
+    caller.data_mut().message_scratch_area().replace(stack);
 
     let process = caller.data_mut().environment().get_process(process_id);
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -39,7 +39,7 @@ pub struct DefaultProcessState {
     module: Option<Arc<WasmtimeCompiledModule<Self>>>,
     // The process configuration
     config: Arc<DefaultProcessConfig>,
-    // A space for received messages to sit when they are received. Receiving messages is 
+    // A space for received messages to sit when they are received. Receiving messages is
     // done in two steps, first the message size is returned to allow the
     // guest to reserve enough space and then the it's received.
     received_message: Option<Message>,
@@ -284,7 +284,6 @@ impl ProcessCtx<DefaultProcessState> for DefaultProcessState {
     fn message_receive_area(&mut self) -> &mut Option<Message> {
         &mut self.received_message
     }
-
 
     fn module_resources(&self) -> &lunatic_process_api::ModuleResources<DefaultProcessState> {
         &self.resources.modules


### PR DESCRIPTION
This allows for messages to be stacked. Calling create_message() adds a message onto the stack, and any message modificatiosn modify the message on the top of the stack.

This is an experiment per a discussion I had with @bkolobara .