### PR TITLE
add metrics API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lunatic-metrics-api"
+version = "0.12.0"
+dependencies = [
+ "anyhow",
+ "log",
+ "lunatic-common-api",
+ "metrics",
+ "wasmtime",
+]
+
+[[package]]
 name = "lunatic-networking-api"
 version = "0.12.0"
 dependencies = [
@@ -1247,6 +1258,7 @@ dependencies = [
  "lunatic-distributed-api",
  "lunatic-error-api",
  "lunatic-messaging-api",
+ "lunatic-metrics-api",
  "lunatic-networking-api",
  "lunatic-process",
  "lunatic-process-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ metrics = [
     "lunatic-process/metrics",
     "lunatic-registry-api/metrics",
     "lunatic-timer-api/metrics",
+    "dep:lunatic-metrics-api",
 ]
 prometheus = ["dep:metrics-exporter-prometheus", "metrics"]
 
@@ -41,6 +42,7 @@ lunatic-registry-api = { workspace = true }
 lunatic-stdout-capture = { workspace = true }
 lunatic-timer-api = { workspace = true }
 lunatic-version-api = { workspace = true }
+lunatic-metrics-api = { workspace = true, optional = true }
 lunatic-wasi-api = { workspace = true }
 
 anyhow = { workspace = true }
@@ -96,6 +98,7 @@ lunatic-registry-api = { path = "crates/lunatic-registry-api", version = "0.12" 
 lunatic-stdout-capture = { path = "crates/lunatic-stdout-capture", version = "0.12" }
 lunatic-timer-api = { path = "crates/lunatic-timer-api", version = "0.12" }
 lunatic-version-api = { path = "crates/lunatic-version-api", version = "0.12" }
+lunatic-metrics-api = { path = "crates/lunatic-metrics-api", version = "0.12" }
 lunatic-wasi-api = { path = "crates/lunatic-wasi-api", version = "0.12" }
 
 anyhow = "1.0"

--- a/crates/lunatic-metrics-api/Cargo.toml
+++ b/crates/lunatic-metrics-api/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lunatic-metrics-api"
+version = "0.12.0"
+edition = "2021"
+description = "Lunatic host functions for metrics"
+homepage = "https://lunatic.solutions"
+repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-metrics"
+license = "Apache-2.0/MIT"
+
+[dependencies]
+anyhow = { workspace = true }
+wasmtime = { workspace = true }
+metrics = { workspace = true }
+lunatic-common-api = { workspace = true }
+log = { workspace = true }

--- a/crates/lunatic-metrics-api/src/lib.rs
+++ b/crates/lunatic-metrics-api/src/lib.rs
@@ -86,7 +86,7 @@ fn gauge<T>(
         &mut caller,
         name_str_ptr,
         name_str_len,
-        "lunatic::metrics::increment_counter",
+        "lunatic::metrics::gauge",
     )?;
 
     gauge!(name, value);

--- a/crates/lunatic-metrics-api/src/lib.rs
+++ b/crates/lunatic-metrics-api/src/lib.rs
@@ -1,0 +1,160 @@
+use lunatic_common_api::{get_memory, IntoTrap};
+use metrics::{counter, decrement_gauge, gauge, histogram, increment_counter, increment_gauge};
+use wasmtime::{Caller, Linker, Trap};
+
+/// Links the [Metrics](https://crates.io/crates/metrics) APIs
+pub fn register<T: 'static>(linker: &mut Linker<T>) -> anyhow::Result<()> {
+    linker.func_wrap("lunatic::metrics", "counter", counter)?;
+    linker.func_wrap("lunatic::metrics", "increment_counter", increment_counter)?;
+    linker.func_wrap("lunatic::metrics", "gauge", gauge)?;
+    linker.func_wrap("lunatic::metrics", "increment_gauge", increment_gauge)?;
+    linker.func_wrap("lunatic::metrics", "decrement_gauge", decrement_gauge)?;
+    linker.func_wrap("lunatic::metrics", "histogram", histogram)?;
+    Ok(())
+}
+
+fn get_string_arg<T>(
+    caller: &mut Caller<T>,
+    name_str_ptr: u32,
+    name_str_len: u32,
+    func_name: &str,
+) -> Result<String, Trap> {
+    let memory = get_memory(caller)?;
+    let memory_slice = memory.data(caller);
+    let name = memory_slice
+        .get(name_str_ptr as usize..(name_str_ptr + name_str_len) as usize)
+        .or_trap(func_name)?;
+    let name = String::from_utf8(name.to_vec()).or_trap(func_name)?;
+    Ok(name)
+}
+
+/// Sets a counter.
+///
+/// Traps:
+/// * If the name is not a valid utf8 string.
+/// * If any memory outside the guest heap space is referenced.
+fn counter<T>(
+    mut caller: Caller<'_, T>,
+    name_str_ptr: u32,
+    name_str_len: u32,
+    value: u64,
+) -> Result<(), Trap> {
+    let name = get_string_arg(
+        &mut caller,
+        name_str_ptr,
+        name_str_len,
+        "lunatic::metrics::counter",
+    )?;
+
+    counter!(name, value);
+    Ok(())
+}
+
+/// Increments a counter.
+///
+/// Traps:
+/// * If the name is not a valid utf8 string.
+/// * If any memory outside the guest heap space is referenced.
+fn increment_counter<T>(
+    mut caller: Caller<'_, T>,
+    name_str_ptr: u32,
+    name_str_len: u32,
+) -> Result<(), Trap> {
+    let name = get_string_arg(
+        &mut caller,
+        name_str_ptr,
+        name_str_len,
+        "lunatic::metrics::increment_counter",
+    )?;
+
+    increment_counter!(name);
+    Ok(())
+}
+
+/// Sets a gauge.
+///
+/// Traps:
+/// * If the name is not a valid utf8 string.
+/// * If any memory outside the guest heap space is referenced.
+fn gauge<T>(
+    mut caller: Caller<'_, T>,
+    name_str_ptr: u32,
+    name_str_len: u32,
+    value: f64,
+) -> Result<(), Trap> {
+    let name = get_string_arg(
+        &mut caller,
+        name_str_ptr,
+        name_str_len,
+        "lunatic::metrics::increment_counter",
+    )?;
+
+    gauge!(name, value);
+    Ok(())
+}
+
+/// Increments a gauge.
+///
+/// Traps:
+/// * If the name is not a valid utf8 string.
+/// * If any memory outside the guest heap space is referenced.
+fn increment_gauge<T>(
+    mut caller: Caller<'_, T>,
+    name_str_ptr: u32,
+    name_str_len: u32,
+    value: f64,
+) -> Result<(), Trap> {
+    let name = get_string_arg(
+        &mut caller,
+        name_str_ptr,
+        name_str_len,
+        "lunatic::metrics::increment_gauge",
+    )?;
+
+    increment_gauge!(name, value);
+    Ok(())
+}
+
+/// Decrements a gauge.
+///
+/// Traps:
+/// * If the name is not a valid utf8 string.
+/// * If any memory outside the guest heap space is referenced.
+fn decrement_gauge<T>(
+    mut caller: Caller<'_, T>,
+    name_str_ptr: u32,
+    name_str_len: u32,
+    value: f64,
+) -> Result<(), Trap> {
+    let name = get_string_arg(
+        &mut caller,
+        name_str_ptr,
+        name_str_len,
+        "lunatic::metrics::decrement_gauge",
+    )?;
+
+    decrement_gauge!(name, value);
+    Ok(())
+}
+
+/// Sets a histogram.
+///
+/// Traps:
+/// * If the name is not a valid utf8 string.
+/// * If any memory outside the guest heap space is referenced.
+fn histogram<T>(
+    mut caller: Caller<'_, T>,
+    name_str_ptr: u32,
+    name_str_len: u32,
+    value: f64,
+) -> Result<(), Trap> {
+    let name = get_string_arg(
+        &mut caller,
+        name_str_ptr,
+        name_str_len,
+        "lunatic::metrics::histogram",
+    )?;
+
+    histogram!(name, value);
+    Ok(())
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -174,6 +174,8 @@ impl ProcessState for DefaultProcessState {
         lunatic_wasi_api::register(linker)?;
         lunatic_registry_api::register(linker)?;
         lunatic_distributed_api::register(linker)?;
+        #[cfg(feature = "metrics")]
+        lunatic_metrics_api::register(linker)?;
         Ok(())
     }
 

--- a/wat/all_imports.wat
+++ b/wat/all_imports.wat
@@ -97,5 +97,12 @@
     (import "lunatic::distributed" "send" (func (param i64 i64) (result i32)))
     (import "lunatic::distributed" "send_receive_skip_search" (func (param i64 i64 i64) (result i32)))
 
+    (import "lunatic::metrics" "counter" (func (param i32 i32 i64)))
+    (import "lunatic::metrics" "increment_counter" (func (param i32 i32)))
+    (import "lunatic::metrics" "gauge" (func (param i32 i32 f64)))
+    (import "lunatic::metrics" "increment_gauge" (func (param i32 i32 f64)))
+    (import "lunatic::metrics" "decrement_gauge" (func (param i32 i32 f64)))
+    (import "lunatic::metrics" "histogram" (func (param i32 i32 f64)))
+
     (func (export "hello") nop)
 )


### PR DESCRIPTION
Expose metrics-rs APIs to wasm modules

Would be nice to have also https://github.com/lunatic-solutions/lunatic/pull/159 merged, so metrics can be shown in prometheus