### PR TITLE
add cargo-lunatic wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "lunatic"
 path = "src/main.rs"
 
+[[bin]]
+name = "cargo-lunatic"
+path = "src/cargo_lunatic.rs"
+
 [features]
 default = ["metrics"]
 metrics = [

--- a/src/cargo_lunatic.rs
+++ b/src/cargo_lunatic.rs
@@ -1,0 +1,17 @@
+use std::{
+    env::{args_os, set_var},
+    process::{exit, Command},
+};
+
+fn main() {
+    set_var("CARGO_BUILD_TARGET", "wasm32-wasi");
+    set_var("CARGO_TARGET_WASM32_WASI_RUNNER", "lunatic");
+    exit(
+        Command::new("cargo")
+            .args(args_os().skip(2))
+            .status()
+            .unwrap()
+            .code()
+            .unwrap(),
+    );
+}


### PR DESCRIPTION
as discussed on Discord, I propose this command `cargo-lunatic` as an addition to lunatic_runtime

it is a thin wrapper that sets environment variables and then calls cargo with the rest of the parameters, effectively replacing `.cargo/config.toml`. It is useful when you have mixed workspaces where you don't necessarily want to globally set the runner for wasm32-wasi or the target to wasm32-wasi

you generally run it with `cargo lunatic ...` where anything following lunatic is then forwarded to cargo, so for example you can now use `cargo lunatic test` or `cargo lunatic run -p web` or `cargo lunatic build --release` and cargo will automatically set target to wasm32-wasi and run the binary with lunatic