### PR TITLE
Add udp and tcp peer addr to wat file

### DIFF
--- a/wat/all_imports.wat
+++ b/wat/all_imports.wat
@@ -54,6 +54,8 @@
     (import "lunatic::networking" "get_udp_socket_ttl" (func (param i64) (result i32)))
     (import "lunatic::networking" "udp_send_to" (func (param i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
     (import "lunatic::networking" "udp_send" (func (param i64 i32 i32 i32) (result i32)))
+    (import "lunatic::networking" "tcp_peer_addr" (func (param i64 i32) (result i32)))
+    (import "lunatic::networking" "udp_peer_addr" (func (param i64 i32) (result i32)))
 
     (import "lunatic::process" "compile_module" (func (param i32 i32 i32) (result i32)))
     (import "lunatic::process" "drop_module" (func (param i64)))


### PR DESCRIPTION
[`tcp_peer_addr`](https://github.com/lunatic-solutions/lunatic/blob/82a4756dfffa29c5562df698e67ecfb07e59341d/crates/lunatic-networking-api/src/tcp.rs#L334) and [`udp_peer_addr`](https://github.com/lunatic-solutions/lunatic/blob/82a4756dfffa29c5562df698e67ecfb07e59341d/crates/lunatic-networking-api/src/udp.rs#L547) were missing from the [`wat/all_imports.wat` file](https://github.com/lunatic-solutions/lunatic/blob/main/wat/all_imports.wat)

Issue #174