### PR TITLE
Run wasm default option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ dashmap = { workspace = true }
 env_logger = "0.9"
 log = { workspace = true }
 metrics-exporter-prometheus = { version = "0.11.0", optional = true }
-regex = "1.5"
+regex = "1.7"
 reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn is_run_implied() -> bool {
     // lunatic <foo.wasm> -> Implied run
     // lunatic run <foo.wasm> -> Explicit run
     // lunatic fdskl <foo.wasm> -> Not implied run
-    let test_re = Regex::new(r"^(--bench|--dir|[^\s]+\.wasm)")
+    let test_re = Regex::new(r"^(--bench|--dir|.+\.wasm)")
         .expect("BUG: Regex error with lunatic::mode::execution::is_run_implied()");
 
     test_re.is_match(&std::env::args().nth(1).unwrap())

--- a/src/mode/cargo_test.rs
+++ b/src/mode/cargo_test.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, env, fs, path::Path, sync::Arc, time::Instant};
 
 use anyhow::{Context, Result};
-use clap::{Subcommand, Parser};
+use clap::{Parser, Subcommand};
 use lunatic_process::{env::LunaticEnvironment, runtimes, wasm::spawn_wasm};
 use lunatic_process_api::ProcessConfigCtx;
 use lunatic_runtime::{DefaultProcessConfig, DefaultProcessState};

--- a/src/mode/cargo_test.rs
+++ b/src/mode/cargo_test.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, env, fs, path::Path, sync::Arc, time::Instant};
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Subcommand, Parser};
 use lunatic_process::{env::LunaticEnvironment, runtimes, wasm::spawn_wasm};
 use lunatic_process_api::ProcessConfigCtx;
 use lunatic_runtime::{DefaultProcessConfig, DefaultProcessState};
@@ -11,11 +11,12 @@ use tokio::sync::RwLock;
 
 #[derive(Parser, Debug)]
 #[command(version)]
+#[command(allow_external_subcommands(true))]
 struct Args {
     /// The `_command` argument is always `run`, from `lunatic run`.
     /// When running in testing mode, commands can be ignored.
-    #[arg()]
-    _command: String,
+    #[command(subcommand)]
+    _command: Option<Commands>,
 
     /// Entry .wasm file
     #[arg()]
@@ -56,6 +57,11 @@ struct Args {
     /// Arguments passed to the guest
     #[arg()]
     wasm_args: Vec<String>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    Run,
 }
 
 pub(crate) async fn test() -> Result<()> {

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use regex::Regex;
+use std::collections::VecDeque;
 
 #[derive(Parser, Debug)]
 #[command(version)]
 #[command(allow_external_subcommands(true))]
 pub struct Args {
     #[command(subcommand)]
-    command: Option<Commands>,
+    command: Commands,
 
     #[cfg(feature = "prometheus")]
     #[command(flatten)]
@@ -30,17 +32,41 @@ enum Commands {
     Node(super::node::Args),
 }
 
+// Lunatic versions under 0.13 implied run
+// This checks whether the 0.12 behaviour is wanted with a regex
+fn is_run_implied() -> bool {
+    if std::env::args().count() < 2 {
+        return false;
+    }
+
+    // lunatic <foo.wasm> -> Implied run
+    // lunatic run <foo.wasm> -> Explicit run
+    // lunatic fdskl <foo.wasm> -> Not implied run
+    let test_re = Regex::new(r"^(--bench|--dir|[^\s]+\.wasm)")
+        .expect("BUG: Regex error with lunatic::mode::execution::is_run_implied()");
+
+    test_re.is_match(&std::env::args().nth(1).unwrap())
+}
+
 pub(crate) async fn execute() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    let args = Args::parse();
+    // Run is implied from lunatic 0.12
+    let args = if is_run_implied() {
+        let mut augmented_args: VecDeque<String> = std::env::args().collect();
+        let first_arg = augmented_args.pop_front().unwrap();
+        augmented_args.push_front("run".to_owned());
+        augmented_args.push_front(first_arg);
+        Args::parse_from(augmented_args)
+    } else {
+        println!("Run is NOT implied!");
+        Args::parse()
+    };
 
     match args.command {
-        Some(Commands::Init) => super::init::start(),
-        Some(Commands::Run(a)) => super::run::start(a).await,
-        Some(Commands::Control(a)) => super::control::start(a).await,
-        Some(Commands::Node(a)) => super::node::start(a).await,
-        // Run with sole .wasm argument
-        None => super::run::start(super::run::Args::parse()).await,
+        Commands::Init => super::init::start(),
+        Commands::Run(a) => super::run::start(a).await,
+        Commands::Control(a) => super::control::start(a).await,
+        Commands::Node(a) => super::node::start(a).await,
     }
 }

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -54,9 +54,7 @@ pub(crate) async fn execute() -> Result<()> {
     // Run is implied from lunatic 0.12
     let args = if is_run_implied() {
         let mut augmented_args: VecDeque<String> = std::env::args().collect();
-        let first_arg = augmented_args.pop_front().unwrap();
-        augmented_args.push_front("run".to_owned());
-        augmented_args.push_front(first_arg);
+        augmented_args.insert(1, "run".to_owned());
         Args::parse_from(augmented_args)
     } else {
         Args::parse()

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -3,9 +3,10 @@ use clap::{Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[command(version)]
+#[command(allow_external_subcommands(true))]
 pub struct Args {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 
     #[cfg(feature = "prometheus")]
     #[command(flatten)]
@@ -35,9 +36,11 @@ pub(crate) async fn execute() -> Result<()> {
     let args = Args::parse();
 
     match args.command {
-        Commands::Init => super::init::start(),
-        Commands::Run(a) => super::run::start(a).await,
-        Commands::Control(a) => super::control::start(a).await,
-        Commands::Node(a) => super::node::start(a).await,
+        Some(Commands::Init) => super::init::start(),
+        Some(Commands::Run(a)) => super::run::start(a).await,
+        Some(Commands::Control(a)) => super::control::start(a).await,
+        Some(Commands::Node(a)) => super::node::start(a).await,
+        // Run with sole .wasm argument
+        None => super::run::start(super::run::Args::parse()).await,
     }
 }

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -59,7 +59,6 @@ pub(crate) async fn execute() -> Result<()> {
         augmented_args.push_front(first_arg);
         Args::parse_from(augmented_args)
     } else {
-        println!("Run is NOT implied!");
         Args::parse()
     };
 

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -3,7 +3,6 @@ use clap::{Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[command(version)]
-#[command(allow_external_subcommands(true))]
 pub struct Args {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
- If subcommand is not found it is assumed it is `lunatic run <wasm>` without having to say `run`
- Allows backwards compatibility to 0.12
- Ergonomics: Less pain migrating to 0.13