### PR TITLE
Add new command

### DIFF
--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -28,7 +28,7 @@ enum Commands {
     /// Starts a node
     Node(super::node::Args),
     /// Create a new project
-    New(super::new::Args)
+    New(super::new::Args),
 }
 
 pub(crate) async fn execute() -> Result<()> {

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -27,6 +27,8 @@ enum Commands {
     Control(super::control::Args),
     /// Starts a node
     Node(super::node::Args),
+    /// Create a new project
+    New(super::new::Args)
 }
 
 pub(crate) async fn execute() -> Result<()> {
@@ -39,5 +41,6 @@ pub(crate) async fn execute() -> Result<()> {
         Commands::Run(a) => super::run::start(a).await,
         Commands::Control(a) => super::control::start(a).await,
         Commands::Node(a) => super::node::start(a).await,
+        Commands::New(a) => super::new::start(a),
     }
 }

--- a/src/mode/execution.rs
+++ b/src/mode/execution.rs
@@ -27,7 +27,7 @@ enum Commands {
     Control(super::control::Args),
     /// Starts a node
     Node(super::node::Args),
-    /// Create a new project
+    /// Create a new Lunatic project
     New(super::new::Args),
 }
 

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -11,3 +11,4 @@ mod control;
 mod init;
 mod node;
 mod run;
+mod new;

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -9,6 +9,6 @@ pub(crate) mod execution;
 mod common;
 mod control;
 mod init;
+mod new;
 mod node;
 mod run;
-mod new;

--- a/src/mode/new.rs
+++ b/src/mode/new.rs
@@ -13,24 +13,30 @@ pub struct Args {
 }
 
 fn add_lunatic_main_file() {
-    let mut file = File::create("src/main.rs").expect("Could not open src/main.rs");
-    file.write_all(b"use std::time::Duration;\n\n\
-    use lunatic::{sleep, spawn_link};\n\n\
-    fn main() {\n\
-        spawn_link!(|| println!(\"Hello, world! I'm a process.\"));\n\
-        sleep(Duration::from_millis(100));\n\
-    }\n").expect("Could not write to src/main.rs");
+    let text = format!(
+        "use std::time::Duration;
+use lunatic::{{sleep, spawn_link}};
+        
+fn main() {{
+    spawn_link!(|| println!(\"Hello, World! I'm a process.\"));
+    sleep(Duration::from_millis(100));
+}}"
+    );
+
+    let mut file = File::create("src/main.rs").expect("Opened src/main.rs");
+
+    file.write_all(text.as_bytes()).expect("\"Hello, World!\" example written in src/main.rs");
 }
 
 pub(crate) fn start(args: Args) -> Result<()> {
     let project_name = &args.new_args[0];
 
-    Command::new("cargo").args(["new", project_name]).status().expect(format!("Failed to create {} project", project_name.as_str()).as_str());
+    Command::new("cargo").args(["new", project_name]).status().expect(format!("Cargo created the {} project", project_name.as_str()).as_str());
 
     let project_path = Path::new(project_name);
-    env::set_current_dir(&project_path).expect(format!("Failed to change to the {} directory", project_name.as_str()).as_str());
+    env::set_current_dir(&project_path).expect(format!("Current directory changed to {}", project_name.as_str()).as_str());
 
-    Command::new("cargo").args(["add", "lunatic"]).status().expect("Failed to add the lunatic dependency");
+    Command::new("cargo").args(["add", "lunatic"]).status().expect("Cargo added the lunatic dependency");
 
     match mode::init::start() {
         Ok(result) => {

--- a/src/mode/new.rs
+++ b/src/mode/new.rs
@@ -8,8 +8,9 @@ use crate::mode;
 #[derive(Parser, Debug)]
 #[command(version)]
 pub struct Args {
+    /// Name of new Lunatic project
     #[arg(index = 1)]
-    pub new_args: Vec<String>,
+    pub name: String,
 }
 
 fn add_lunatic_main_file() {
@@ -28,7 +29,7 @@ fn main() {{
 }
 
 pub(crate) fn start(args: Args) -> Result<()> {
-    let project_name = &args.new_args[0];
+    let project_name = &args.name;
 
     Command::new("cargo")
         .args(["new", project_name])
@@ -40,13 +41,15 @@ pub(crate) fn start(args: Args) -> Result<()> {
         .unwrap_or_else(|_| panic!("Current directory changed to {}", project_name.as_str()));
 
     Command::new("cargo")
-        .args(["add", "lunatic"])
+        .args(["add", "-q", "lunatic"])
         .status()
         .expect("Cargo added the lunatic dependency");
 
     match mode::init::start() {
         Ok(result) => {
             add_lunatic_main_file();
+
+            println!("\nLunatic is ready 🚀");
             Ok(result)
         }
         Err(error) => Err(anyhow!(

--- a/src/mode/new.rs
+++ b/src/mode/new.rs
@@ -1,0 +1,38 @@
+use std::{process::Command, env, path::Path, io::Write};
+
+use clap::Parser;
+use anyhow::Result;
+
+use crate::mode;
+
+#[derive(Parser, Debug)]
+#[command(version)]
+pub struct Args {
+    #[arg(index = 1)]
+    pub new_args: Vec<String>,
+}
+
+pub(crate) fn start(args: Args) -> Result<()> {
+    Command::new("cargo").args(["new", &args.new_args[0]]).status().expect(format!("failed to create {} project", &args.new_args[0].as_str()).as_str());
+
+    let new_directory = Path::new(&args.new_args[0]);
+    env::set_current_dir(&new_directory).expect(format!("failed to change to the {} directory", &args.new_args[0].as_str()).as_str());
+
+    Command::new("cargo").args(["add", "lunatic"]).status().expect("failed to add lunatic dependency");
+
+    mode::init::start();
+
+    let src_directory = Path::new("src");
+    env::set_current_dir(&src_directory).expect("failed to change to the \"src\" directory");
+
+    let mut f = std::fs::OpenOptions::new().write(true).truncate(true).open("./main.rs")?;
+    f.write_all(b"use std::time::Duration;\n\n\
+    use lunatic::{sleep, spawn_link};\n\n\
+    fn main() {\n\
+        spawn_link!(|| println!(\"Hello, world! I'm a process.\"));\n\
+        sleep(Duration::from_millis(100));\n\
+    }\n")?;
+    f.flush()?;
+
+    Ok(())
+}

--- a/src/mode/new.rs
+++ b/src/mode/new.rs
@@ -31,29 +31,36 @@ fn main() {{
 pub(crate) fn start(args: Args) -> Result<()> {
     let project_name = &args.name;
 
-    Command::new("cargo")
+    let new_status = Command::new("cargo")
         .args(["new", project_name])
         .status()
-        .unwrap_or_else(|_| panic!("Cargo created the {} project", project_name.as_str()));
+        .expect("'cargo new' should execute");
+
+    if !new_status.success() {
+        return Err(anyhow!("Could not create a new Lunatic project"));
+    }
 
     let project_path = Path::new(project_name);
-    env::set_current_dir(project_path)
-        .unwrap_or_else(|_| panic!("Current directory changed to {}", project_name.as_str()));
+    env::set_current_dir(project_path).expect("Current directory is changed to the new project");
 
-    Command::new("cargo")
+    let add_status = Command::new("cargo")
         .args(["add", "-q", "lunatic"])
         .status()
-        .expect("Cargo added the lunatic dependency");
+        .expect("'cargo add' should execute");
+
+    if !add_status.success() {
+        return Err(anyhow!("Could not add the Lunatic dependency"));
+    }
 
     match mode::init::start() {
         Ok(result) => {
             add_lunatic_main_file();
 
-            println!("\nLunatic is ready 🚀");
+            println!("\nYour Lunatic project is ready 🚀");
             Ok(result)
         }
         Err(error) => Err(anyhow!(
-            "Could not initialize a lunatic project in {}: {}.",
+            "Could not initialize a Lunatic project in {}: {}",
             &project_name,
             error
         )),

--- a/src/mode/new.rs
+++ b/src/mode/new.rs
@@ -1,7 +1,7 @@
-use std::{process::Command, env, path::Path, fs::File, io::Write};
+use std::{env, fs::File, io::Write, path::Path, process::Command};
 
-use clap::Parser;
 use anyhow::{anyhow, Result};
+use clap::Parser;
 
 use crate::mode;
 
@@ -13,30 +13,36 @@ pub struct Args {
 }
 
 fn add_lunatic_main_file() {
-    let text = format!(
-        "use std::time::Duration;
+    let text = "use std::time::Duration;
 use lunatic::{{sleep, spawn_link}};
         
 fn main() {{
     spawn_link!(|| println!(\"Hello, World! I'm a process.\"));
     sleep(Duration::from_millis(100));
-}}"
-    );
+}}";
 
     let mut file = File::create("src/main.rs").expect("Opened src/main.rs");
 
-    file.write_all(text.as_bytes()).expect("\"Hello, World!\" example written in src/main.rs");
+    file.write_all(text.as_bytes())
+        .expect("\"Hello, World!\" example written in src/main.rs");
 }
 
 pub(crate) fn start(args: Args) -> Result<()> {
     let project_name = &args.new_args[0];
 
-    Command::new("cargo").args(["new", project_name]).status().expect(format!("Cargo created the {} project", project_name.as_str()).as_str());
+    Command::new("cargo")
+        .args(["new", project_name])
+        .status()
+        .unwrap_or_else(|_| panic!("Cargo created the {} project", project_name.as_str()));
 
     let project_path = Path::new(project_name);
-    env::set_current_dir(&project_path).expect(format!("Current directory changed to {}", project_name.as_str()).as_str());
+    env::set_current_dir(project_path)
+        .unwrap_or_else(|_| panic!("Current directory changed to {}", project_name.as_str()));
 
-    Command::new("cargo").args(["add", "lunatic"]).status().expect("Cargo added the lunatic dependency");
+    Command::new("cargo")
+        .args(["add", "lunatic"])
+        .status()
+        .expect("Cargo added the lunatic dependency");
 
     match mode::init::start() {
         Ok(result) => {
@@ -47,6 +53,6 @@ pub(crate) fn start(args: Args) -> Result<()> {
             "Could not initialize a lunatic project in {}: {}.",
             &project_name,
             error
-        ))
+        )),
     }
 }


### PR DESCRIPTION
This PR adds a new command to Lunatic: `lunatic new <project-name>`.

It generates a new Lunatic Rust project with the name `<project-name>` by performing the following steps:
1) Run `cargo new <project_name>` to create the project.
2) Change the directory to `<project_name>`.
3) Add the latest version of Lunatic as a dependency to the project.
4) Run the `init` command to add the `.cargo/config.toml` file.
5) Replace Cargo's default `src/main.rs` with an example that uses Lunatic. 

The example program is a modified version of Bernard's example from [Writing Rust the Erlang way](https://youtu.be/NZ1rpQSLvg8?t=695).