### PR TITLE
Add better error message when module is not found

### DIFF
--- a/src/mode/common.rs
+++ b/src/mode/common.rs
@@ -54,7 +54,10 @@ pub async fn run_wasm(args: RunWasm) -> Result<()> {
     }
 
     // Spawn main process
-    let module = std::fs::read(&path)?;
+    let module = std::fs::read(&path).map_err(|err| match err.kind() {
+        std::io::ErrorKind::NotFound => anyhow!("Module '{}' not found", path.display()),
+        _ => err.into(),
+    })?;
     let module: RawWasm = if let Some(dist) = args.distributed.as_ref() {
         dist.control.add_module(module).await?
     } else {


### PR DESCRIPTION
Fixes #180 

When a module is not found when using `run`, a better error is shown.

Before:
```
❯ lunatic run foo.wasm
Error: No such file or directory (os error 2)
```

After:
```
❯ lunatic run foo.wasm
Error: Module 'foo.wasm' not found
```

The main concern is that the No such file or directory error could come from the foo.wasm itself trying to open a file.