### PR TITLE
Refactor CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,10 @@ jobs:
       - name: Generate release notes
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          awk '/## v[0-9]+\.[0-9]+.[0-9]+/ && STATE=="show" { exit }
+          awk '/^## v[0-9]+\.[0-9]+\.[0-9]+/ && STATE=="show" { exit }
               STATE=="show";
-              /## ${{ steps.getReleaseName.outputs.RELEASE_NAME }}/ { STATE="catch" }
-              /Released [0-9]+-[0-9]+-[0-9]+/ && STATE=="catch" { STATE="show" }' CHANGELOG.md \
+              /^## ${{ steps.getReleaseName.outputs.RELEASE_NAME }}/ { STATE="catch" }
+              /^Released [0-9]+-[0-9]+-[0-9]+/ && STATE=="catch" { STATE="show" }' CHANGELOG.md \
           | awk 'NF { SHOW=1 } SHOW' > RELEASE_NOTES.md
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             content_type: application/zip
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install latest Rust
         if: runner.os != 'macOS'
         uses: actions-rs/toolchain@v1
@@ -80,12 +80,21 @@ jobs:
       - name: Get release name
         if: startsWith(github.ref, 'refs/tags/')
         id: getReleaseName
-        run: echo ::set-output name=RELEASE_NAME::${GITHUB_REF/refs\/tags\//}
+        run: echo "RELEASE_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+      - name: Generate release notes
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          awk '/## v[0-9]+\.[0-9]+.[0-9]+/ && STATE=="show" { exit }
+              STATE=="show";
+              /## ${{ steps.getReleaseName.outputs.RELEASE_NAME }}/ { STATE="catch" }
+              /Released [0-9]+-[0-9]+-[0-9]+/ && STATE=="catch" { STATE="show" }' CHANGELOG.md \
+          | awk 'NF { SHOW=1 } SHOW' > RELEASE_NOTES.md
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.getReleaseName.outputs.RELEASE_NAME }}
           name: Lunatic ${{ steps.getReleaseName.outputs.RELEASE_NAME }}
+          body_path: RELEASE_NOTES.md
           draft: true
           files: ${{ matrix.asset_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Lunatic Changelog
 
+## v0.12.1
+
+Released 2023-01-17.
+
+### Changes
+
+- CI workflow refactored
+
 ## v0.12.0
 
 Released 2022-11-15.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Lunatic Changelog
 
-## v0.12.1
-
-Released 2023-01-17.
-
-### Changes
-
-- CI workflow refactored
-
 ## v0.12.0
 
 Released 2022-11-15.


### PR DESCRIPTION
- Updated `actions/checkout` to v3
- Removed `::set-output` as deprecated (see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- Added a command to generate release notes from `CHANGELOG.md`

Release action test: https://github.com/shamilsan/lunatic/actions/runs/3942782116
Release published: https://github.com/shamilsan/lunatic/releases/tag/v0.12.1 (from changelog: https://github.com/shamilsan/lunatic/blob/ebf35ea/CHANGELOG.md)