### PR TITLE
Add environment spawn limit

### DIFF
--- a/crates/lunatic-distributed/src/distributed/server.rs
+++ b/crates/lunatic-distributed/src/distributed/server.rs
@@ -181,6 +181,8 @@ where
         None => ctx.envs.create(environment_id).await,
     };
 
+    let spawn_permit = env.can_spawn_next_process().await?;
+
     let distributed = ctx.distributed.clone();
     let runtime = ctx.runtime.clone();
     let state = T::new_dist_state(env.clone(), distributed, runtime, module.clone(), config)?;
@@ -193,6 +195,7 @@ where
         &function,
         params,
         None,
+        spawn_permit,
     )
     .await?;
     Ok(Ok(proc.id()))

--- a/crates/lunatic-distributed/src/distributed/server.rs
+++ b/crates/lunatic-distributed/src/distributed/server.rs
@@ -181,7 +181,7 @@ where
         None => ctx.envs.create(environment_id).await,
     };
 
-    let spawn_permit = env.can_spawn_next_process().await?;
+    env.can_spawn_next_process().await?;
 
     let distributed = ctx.distributed.clone();
     let runtime = ctx.runtime.clone();
@@ -195,7 +195,6 @@ where
         &function,
         params,
         None,
-        spawn_permit,
     )
     .await?;
     Ok(Ok(proc.id()))

--- a/crates/lunatic-process-api/src/lib.rs
+++ b/crates/lunatic-process-api/src/lib.rs
@@ -581,6 +581,12 @@ where
         ));
     }
 
+    let env = caller.data().environment();
+    let spawn_permit = env
+        .can_spawn_next_process()
+        .await
+        .or_trap("lunatic::process:spawn: Process spawn limit reached.")?;
+
     let state = caller.data();
 
     if !state.is_initialized() {
@@ -677,7 +683,14 @@ where
     // set state instead of config TODO
     let env = caller.data().environment();
     let (proc_or_error_id, result) = match lunatic_process::wasm::spawn_wasm(
-        env, runtime, &module, state, function, params, link,
+        env,
+        runtime,
+        &module,
+        state,
+        function,
+        params,
+        link,
+        spawn_permit,
     )
     .await
     {

--- a/crates/lunatic-process-api/src/lib.rs
+++ b/crates/lunatic-process-api/src/lib.rs
@@ -1,6 +1,5 @@
 use std::{
     convert::{TryFrom, TryInto},
-    future::Future,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -156,9 +155,37 @@ where
         config_set_can_spawn_processes,
     )?;
 
-    linker.func_wrap8_async("lunatic::process", "spawn", spawn)?;
-
-    linker.func_wrap1_async("lunatic::process", "sleep_ms", sleep_ms)?;
+    linker.func_wrap8_async(
+        "lunatic::process",
+        "spawn",
+        |caller,
+         link,
+         config_id,
+         module_id,
+         func_str_ptr,
+         func_str_len,
+         params_ptr,
+         params_len,
+         id_ptr| {
+            Box::new(async move {
+                spawn(
+                    caller,
+                    link,
+                    config_id,
+                    module_id,
+                    func_str_ptr,
+                    func_str_len,
+                    params_ptr,
+                    params_len,
+                    id_ptr,
+                )
+                .await
+            })
+        },
+    )?;
+    linker.func_wrap1_async("lunatic::process", "sleep_ms", |caller, millis| {
+        Box::new(async move { sleep_ms(caller, millis).await })
+    })?;
     linker.func_wrap("lunatic::process", "die_when_link_dies", die_when_link_dies)?;
 
     linker.func_wrap("lunatic::process", "process_id", process_id)?;
@@ -179,7 +206,7 @@ where
 // *  0 on success - The ID of the newly created module is written to **id_ptr**
 // *  1 on error   - The error ID is written to **id_ptr**
 // * -1 in case the process doesn't have permission to compile modules.
-fn compile_module<T>(
+pub fn compile_module<T>(
     mut caller: Caller<T>,
     module_data_ptr: u32,
     module_data_len: u32,
@@ -235,7 +262,7 @@ where
 //
 // Traps:
 // * If the module ID doesn't exist.
-fn drop_module<T: ProcessState + ProcessCtx<T>>(
+pub fn drop_module<T: ProcessState + ProcessCtx<T>>(
     mut caller: Caller<T>,
     module_id: u64,
 ) -> Result<()> {
@@ -260,7 +287,7 @@ fn drop_module<T: ProcessState + ProcessCtx<T>>(
 // Returns:
 // * ID of newly created configuration in case of success
 // * -1 in case the process doesn't have permission to create new configurations
-fn create_config<T>(mut caller: Caller<T>) -> i64
+pub fn create_config<T>(mut caller: Caller<T>) -> i64
 where
     T: ProcessState + ProcessCtx<T>,
     T::Config: ProcessConfigCtx,
@@ -280,7 +307,7 @@ where
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn drop_config<T: ProcessState + ProcessCtx<T>>(
+pub fn drop_config<T: ProcessState + ProcessCtx<T>>(
     mut caller: Caller<T>,
     config_id: u64,
 ) -> Result<()> {
@@ -301,7 +328,7 @@ fn drop_config<T: ProcessState + ProcessCtx<T>>(
 // Traps:
 // * If max_memory is bigger than the platform maximum.
 // * If the config ID doesn't exist.
-fn config_set_max_memory<T: ProcessState + ProcessCtx<T>>(
+pub fn config_set_max_memory<T: ProcessState + ProcessCtx<T>>(
     mut caller: Caller<T>,
     config_id: u64,
     max_memory: u64,
@@ -321,7 +348,7 @@ fn config_set_max_memory<T: ProcessState + ProcessCtx<T>>(
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn config_get_max_memory<T: ProcessState + ProcessCtx<T>>(
+pub fn config_get_max_memory<T: ProcessState + ProcessCtx<T>>(
     caller: Caller<T>,
     config_id: u64,
 ) -> Result<u64> {
@@ -340,7 +367,7 @@ fn config_get_max_memory<T: ProcessState + ProcessCtx<T>>(
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn config_set_max_fuel<T: ProcessState + ProcessCtx<T>>(
+pub fn config_set_max_fuel<T: ProcessState + ProcessCtx<T>>(
     mut caller: Caller<T>,
     config_id: u64,
     max_fuel: u64,
@@ -365,7 +392,7 @@ fn config_set_max_fuel<T: ProcessState + ProcessCtx<T>>(
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn config_get_max_fuel<T: ProcessState + ProcessCtx<T>>(
+pub fn config_get_max_fuel<T: ProcessState + ProcessCtx<T>>(
     caller: Caller<T>,
     config_id: u64,
 ) -> Result<u64> {
@@ -385,7 +412,7 @@ fn config_get_max_fuel<T: ProcessState + ProcessCtx<T>>(
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn config_can_compile_modules<T>(caller: Caller<T>, config_id: u64) -> Result<u32>
+pub fn config_can_compile_modules<T>(caller: Caller<T>, config_id: u64) -> Result<u32>
 where
     T: ProcessState + ProcessCtx<T>,
     T::Config: ProcessConfigCtx,
@@ -404,7 +431,11 @@ where
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn config_set_can_compile_modules<T>(mut caller: Caller<T>, config_id: u64, can: u32) -> Result<()>
+pub fn config_set_can_compile_modules<T>(
+    mut caller: Caller<T>,
+    config_id: u64,
+    can: u32,
+) -> Result<()>
 where
     T: ProcessState + ProcessCtx<T>,
     T::Config: ProcessConfigCtx,
@@ -423,7 +454,7 @@ where
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn config_can_create_configs<T>(caller: Caller<T>, config_id: u64) -> Result<u32>
+pub fn config_can_create_configs<T>(caller: Caller<T>, config_id: u64) -> Result<u32>
 where
     T: ProcessState + ProcessCtx<T>,
     T::Config: ProcessConfigCtx,
@@ -442,7 +473,11 @@ where
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn config_set_can_create_configs<T>(mut caller: Caller<T>, config_id: u64, can: u32) -> Result<()>
+pub fn config_set_can_create_configs<T>(
+    mut caller: Caller<T>,
+    config_id: u64,
+    can: u32,
+) -> Result<()>
 where
     T: ProcessState + ProcessCtx<T>,
     T::Config: ProcessConfigCtx,
@@ -460,7 +495,7 @@ where
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn config_can_spawn_processes<T>(caller: Caller<T>, config_id: u64) -> Result<u32>
+pub fn config_can_spawn_processes<T>(caller: Caller<T>, config_id: u64) -> Result<u32>
 where
     T: ProcessState + ProcessCtx<T>,
     T::Config: ProcessConfigCtx,
@@ -479,7 +514,11 @@ where
 //
 // Traps:
 // * If the config ID doesn't exist.
-fn config_set_can_spawn_processes<T>(mut caller: Caller<T>, config_id: u64, can: u32) -> Result<()>
+pub fn config_set_can_spawn_processes<T>(
+    mut caller: Caller<T>,
+    config_id: u64,
+    can: u32,
+) -> Result<()>
 where
     T: ProcessState + ProcessCtx<T>,
     T::Config: ProcessConfigCtx,
@@ -520,8 +559,8 @@ where
 // * If the params array is in a wrong format.
 // * If any memory outside the guest heap space is referenced.
 #[allow(clippy::too_many_arguments)]
-fn spawn<T>(
-    mut caller: Caller<T>,
+pub async fn spawn<T>(
+    mut caller: Caller<'_, T>,
     link: i64,
     config_id: i64,
     module_id: i64,
@@ -530,144 +569,137 @@ fn spawn<T>(
     params_ptr: u32,
     params_len: u32,
     id_ptr: u32,
-) -> Box<dyn Future<Output = Result<u32>> + Send + '_>
+) -> Result<u32>
 where
     T: ProcessState + ProcessCtx<T> + ErrorCtx + LunaticWasiCtx + ResourceLimiter + Send + 'static,
     for<'a> &'a T: Send,
     T::Config: ProcessConfigCtx,
 {
-    Box::new(async move {
-        if !caller.data().config().can_spawn_processes() {
-            return Err(anyhow!(
-                "Process doesn't have permissions to spawn sub-processes"
-            ));
-        }
+    if !caller.data().config().can_spawn_processes() {
+        return Err(anyhow!(
+            "Process doesn't have permissions to spawn sub-processes"
+        ));
+    }
 
-        let state = caller.data();
+    let state = caller.data();
 
-        if !state.is_initialized() {
-            return Err(anyhow!("Cannot spawn process during module initialization"));
-        }
+    if !state.is_initialized() {
+        return Err(anyhow!("Cannot spawn process during module initialization"));
+    }
 
-        let config = match config_id {
-            -1 => state.config().clone(),
-            config_id => Arc::new(
-                caller
-                    .data()
-                    .config_resources()
-                    .get(config_id as u64)
-                    .or_trap("lunatic::process::spawn: Config ID doesn't exist")?
-                    .clone(),
-            ),
-        };
-
-        let module = match module_id {
-            -1 => state.module().clone(),
-            module_id => caller
+    let config = match config_id {
+        -1 => state.config().clone(),
+        config_id => Arc::new(
+            caller
                 .data()
-                .module_resources()
-                .get(module_id as u64)
-                .or_trap("lunatic::process::spawn: Module ID doesn't exist")?
+                .config_resources()
+                .get(config_id as u64)
+                .or_trap("lunatic::process::spawn: Config ID doesn't exist")?
                 .clone(),
-        };
+        ),
+    };
 
-        let mut state = state.new_state(module.clone(), config)?;
+    let module = match module_id {
+        -1 => state.module().clone(),
+        module_id => caller
+            .data()
+            .module_resources()
+            .get(module_id as u64)
+            .or_trap("lunatic::process::spawn: Module ID doesn't exist")?
+            .clone(),
+    };
 
-        let memory = get_memory(&mut caller)?;
-        let func_str = memory
-            .data(&caller)
-            .get(func_str_ptr as usize..(func_str_ptr + func_str_len) as usize)
-            .or_trap("lunatic::process::spawn")?;
-        let function = std::str::from_utf8(func_str).or_trap("lunatic::process::spawn")?;
-        let params = memory
-            .data(&caller)
-            .get(params_ptr as usize..(params_ptr + params_len) as usize)
-            .or_trap("lunatic::process::spawn")?;
-        let params_chunks = &mut params.chunks_exact(17);
-        let params = params_chunks
-            .map(|chunk| {
-                let value = u128::from_le_bytes(chunk[1..].try_into()?);
-                let result = match chunk[0] {
-                    0x7F => Val::I32(value as i32),
-                    0x7E => Val::I64(value as i64),
-                    0x7B => Val::V128(value),
-                    _ => return Err(anyhow!("Unsupported type ID")),
-                };
-                Ok(result)
-            })
-            .collect::<Result<Vec<_>>>()?;
-        if !params_chunks.remainder().is_empty() {
-            return Err(anyhow!(
-                "Params array must be in chunks of 17 bytes, but {} bytes remained",
-                params_chunks.remainder().len()
-            ));
+    let mut state = state.new_state(module.clone(), config)?;
+
+    let memory = get_memory(&mut caller)?;
+    let func_str = memory
+        .data(&caller)
+        .get(func_str_ptr as usize..(func_str_ptr + func_str_len) as usize)
+        .or_trap("lunatic::process::spawn")?;
+    let function = std::str::from_utf8(func_str).or_trap("lunatic::process::spawn")?;
+    let params = memory
+        .data(&caller)
+        .get(params_ptr as usize..(params_ptr + params_len) as usize)
+        .or_trap("lunatic::process::spawn")?;
+    let params_chunks = &mut params.chunks_exact(17);
+    let params = params_chunks
+        .map(|chunk| {
+            let value = u128::from_le_bytes(chunk[1..].try_into()?);
+            let result = match chunk[0] {
+                0x7F => Val::I32(value as i32),
+                0x7E => Val::I64(value as i64),
+                0x7B => Val::V128(value),
+                _ => return Err(anyhow!("Unsupported type ID")),
+            };
+            Ok(result)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if !params_chunks.remainder().is_empty() {
+        return Err(anyhow!(
+            "Params array must be in chunks of 17 bytes, but {} bytes remained",
+            params_chunks.remainder().len()
+        ));
+    }
+    // Should processes be linked together?
+    let link: Option<(Option<i64>, Arc<dyn Process>)> = match link {
+        0 => None,
+        tag => {
+            let id = caller.data().id();
+            let signal_mailbox = caller.data().signal_mailbox().clone();
+            let process = WasmProcess::new(id, signal_mailbox.0);
+            Some((Some(tag), Arc::new(process)))
         }
-        // Should processes be linked together?
-        let link: Option<(Option<i64>, Arc<dyn Process>)> = match link {
-            0 => None,
-            tag => {
-                let id = caller.data().id();
-                let signal_mailbox = caller.data().signal_mailbox().clone();
-                let process = WasmProcess::new(id, signal_mailbox.0);
-                Some((Some(tag), Arc::new(process)))
-            }
-        };
+    };
 
-        let runtime = caller.data().runtime().clone();
+    let runtime = caller.data().runtime().clone();
 
-        // Inherit stdout and stderr streams if they are redirected by the parent.
-        let stdout = if let Some(stdout) = caller.data().get_stdout() {
-            let next_stream = stdout.next();
-            state.set_stdout(next_stream.clone());
-            Some((stdout.clone(), next_stream))
-        } else {
-            None
-        };
-        if let Some(stderr) = caller.data().get_stderr() {
-            // If stderr is same as stdout, use same `next_stream`.
-            if let Some((stdout, next_stream)) = stdout {
-                if &stdout == stderr {
-                    state.set_stderr(next_stream);
-                } else {
-                    state.set_stderr(stderr.next());
-                }
+    // Inherit stdout and stderr streams if they are redirected by the parent.
+    let stdout = if let Some(stdout) = caller.data().get_stdout() {
+        let next_stream = stdout.next();
+        state.set_stdout(next_stream.clone());
+        Some((stdout.clone(), next_stream))
+    } else {
+        None
+    };
+    if let Some(stderr) = caller.data().get_stderr() {
+        // If stderr is same as stdout, use same `next_stream`.
+        if let Some((stdout, next_stream)) = stdout {
+            if &stdout == stderr {
+                state.set_stderr(next_stream);
             } else {
                 state.set_stderr(stderr.next());
             }
+        } else {
+            state.set_stderr(stderr.next());
         }
+    }
 
-        // set state instead of config TODO
-        let env = caller.data().environment();
-        let (proc_or_error_id, result) = match lunatic_process::wasm::spawn_wasm(
-            env, runtime, &module, state, function, params, link,
+    // set state instead of config TODO
+    let env = caller.data().environment();
+    let (proc_or_error_id, result) = match lunatic_process::wasm::spawn_wasm(
+        env, runtime, &module, state, function, params, link,
+    )
+    .await
+    {
+        Ok((_, process)) => (process.id(), 0),
+        Err(error) => (caller.data_mut().error_resources_mut().add(error), 1),
+    };
+
+    memory
+        .write(
+            &mut caller,
+            id_ptr as usize,
+            &proc_or_error_id.to_le_bytes(),
         )
-        .await
-        {
-            Ok((_, process)) => (process.id(), 0),
-            Err(error) => (caller.data_mut().error_resources_mut().add(error), 1),
-        };
-
-        memory
-            .write(
-                &mut caller,
-                id_ptr as usize,
-                &proc_or_error_id.to_le_bytes(),
-            )
-            .or_trap("lunatic::process::spawn")?;
-        Ok(result)
-    })
+        .or_trap("lunatic::process::spawn")?;
+    Ok(result)
 }
 
 // lunatic::process::sleep_ms(millis: u64)
 //
 // Suspend process for `millis`.
-fn sleep_ms<T: ProcessState + ProcessCtx<T>>(
-    _: Caller<T>,
-    millis: u64,
-) -> Box<dyn Future<Output = ()> + Send + '_> {
-    Box::new(async move {
-        tokio::time::sleep(Duration::from_millis(millis)).await;
-    })
+pub async fn sleep_ms<T: ProcessState + ProcessCtx<T>>(_: Caller<'_, T>, millis: u64) {
+    tokio::time::sleep(Duration::from_millis(millis)).await
 }
 
 // Defines what happens to this process if one of the linked processes notifies us that it died.
@@ -677,7 +709,7 @@ fn sleep_ms<T: ProcessState + ProcessCtx<T>>(
 // 2. `trap != 0` the process will die and notify all linked processes of its death.
 //
 // The default behaviour for a newly spawned process is 2.
-fn die_when_link_dies<T: ProcessState + ProcessCtx<T>>(mut caller: Caller<T>, trap: u32) {
+pub fn die_when_link_dies<T: ProcessState + ProcessCtx<T>>(mut caller: Caller<T>, trap: u32) {
     caller
         .data_mut()
         .signal_mailbox()
@@ -687,12 +719,12 @@ fn die_when_link_dies<T: ProcessState + ProcessCtx<T>>(mut caller: Caller<T>, tr
 }
 
 // Returns ID of the process currently running
-fn process_id<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>) -> u64 {
+pub fn process_id<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>) -> u64 {
     caller.data().id()
 }
 
 // Returns ID of the environment in which the process is currently running
-fn environment_id<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>) -> u64 {
+pub fn environment_id<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>) -> u64 {
     caller.data().environment().id()
 }
 
@@ -701,7 +733,7 @@ fn environment_id<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>) -> u64 {
 //
 // Traps:
 // * If the process ID doesn't exist.
-fn link<T: ProcessState + ProcessCtx<T>>(
+pub fn link<T: ProcessState + ProcessCtx<T>>(
     mut caller: Caller<T>,
     tag: i64,
     process_id: u64,
@@ -745,7 +777,10 @@ fn link<T: ProcessState + ProcessCtx<T>>(
 //
 // Traps:
 // * If the process ID doesn't exist.
-fn unlink<T: ProcessState + ProcessCtx<T>>(mut caller: Caller<T>, process_id: u64) -> Result<()> {
+pub fn unlink<T: ProcessState + ProcessCtx<T>>(
+    mut caller: Caller<T>,
+    process_id: u64,
+) -> Result<()> {
     // Create handle to itself
     let this_process_id = caller.data().id();
 
@@ -773,7 +808,7 @@ fn unlink<T: ProcessState + ProcessCtx<T>>(mut caller: Caller<T>, process_id: u6
 //
 // Traps:
 // * If the process ID doesn't exist.
-fn kill<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>, process_id: u64) -> Result<()> {
+pub fn kill<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>, process_id: u64) -> Result<()> {
     // Send kill signal to process
     if let Some(process) = caller.data().environment().get_process(process_id) {
         process.send(Signal::Kill);
@@ -782,7 +817,7 @@ fn kill<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>, process_id: u64) -> 
 }
 
 // Checks to see if a process exists
-fn exists<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>, process_id: u64) -> i32 {
+pub fn exists<T: ProcessState + ProcessCtx<T>>(caller: Caller<T>, process_id: u64) -> i32 {
     caller
         .data()
         .environment()

--- a/crates/lunatic-process-api/src/lib.rs
+++ b/crates/lunatic-process-api/src/lib.rs
@@ -158,7 +158,7 @@ where
     linker.func_wrap8_async(
         "lunatic::process",
         "spawn",
-        |caller,
+        |mut caller,
          link,
          config_id,
          module_id,
@@ -169,7 +169,7 @@ where
          id_ptr| {
             Box::new(async move {
                 spawn(
-                    caller,
+                    &mut caller,
                     link,
                     config_id,
                     module_id,
@@ -560,7 +560,7 @@ where
 // * If any memory outside the guest heap space is referenced.
 #[allow(clippy::too_many_arguments)]
 pub async fn spawn<T>(
-    mut caller: Caller<'_, T>,
+    caller: &mut Caller<'_, T>,
     link: i64,
     config_id: i64,
     module_id: i64,
@@ -611,7 +611,7 @@ where
 
     let mut state = state.new_state(module.clone(), config)?;
 
-    let memory = get_memory(&mut caller)?;
+    let memory = get_memory(caller)?;
     let func_str = memory
         .data(&caller)
         .get(func_str_ptr as usize..(func_str_ptr + func_str_len) as usize)
@@ -686,11 +686,7 @@ where
     };
 
     memory
-        .write(
-            &mut caller,
-            id_ptr as usize,
-            &proc_or_error_id.to_le_bytes(),
-        )
+        .write(caller, id_ptr as usize, &proc_or_error_id.to_le_bytes())
         .or_trap("lunatic::process::spawn")?;
     Ok(result)
 }

--- a/crates/lunatic-process-api/src/lib.rs
+++ b/crates/lunatic-process-api/src/lib.rs
@@ -582,8 +582,7 @@ where
     }
 
     let env = caller.data().environment();
-    let spawn_permit = env
-        .can_spawn_next_process()
+    env.can_spawn_next_process()
         .await
         .or_trap("lunatic::process:spawn: Process spawn limit reached.")?;
 
@@ -683,14 +682,7 @@ where
     // set state instead of config TODO
     let env = caller.data().environment();
     let (proc_or_error_id, result) = match lunatic_process::wasm::spawn_wasm(
-        env,
-        runtime,
-        &module,
-        state,
-        function,
-        params,
-        link,
-        spawn_permit,
+        env, runtime, &module, state, function, params, link,
     )
     .await
     {

--- a/crates/lunatic-process/src/env.rs
+++ b/crates/lunatic-process/src/env.rs
@@ -1,19 +1,23 @@
+use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
+use tokio::sync::OwnedSemaphorePermit;
 
 use crate::{Process, Signal};
 
+#[async_trait]
 pub trait Environment: Send + Sync {
     fn id(&self) -> u64;
     fn get_next_process_id(&self) -> u64;
     fn get_process(&self, id: u64) -> Option<Arc<dyn Process>>;
-    fn add_process(&self, id: u64, proc: Arc<dyn Process>);
+    fn add_process(&self, id: u64, proc: Arc<dyn Process>, permit: Option<OwnedSemaphorePermit>);
     fn remove_process(&self, id: u64);
     fn process_count(&self) -> usize;
+    async fn can_spawn_next_process(&self) -> Result<Option<OwnedSemaphorePermit>>;
     fn send(&self, id: u64, signal: Signal);
 }
 
@@ -25,11 +29,13 @@ pub trait Environments: Send + Sync {
     async fn get(&self, id: u64) -> Option<Arc<Self::Env>>;
 }
 
+type ProcessEntry = (Arc<dyn Process>, Option<OwnedSemaphorePermit>);
+
 #[derive(Clone)]
 pub struct LunaticEnvironment {
     environment_id: u64,
     next_process_id: Arc<AtomicU64>,
-    processes: Arc<DashMap<u64, Arc<dyn Process>>>,
+    processes: Arc<DashMap<u64, ProcessEntry>>,
 }
 
 impl LunaticEnvironment {
@@ -42,13 +48,14 @@ impl LunaticEnvironment {
     }
 }
 
+#[async_trait]
 impl Environment for LunaticEnvironment {
     fn get_process(&self, id: u64) -> Option<Arc<dyn Process>> {
-        self.processes.get(&id).map(|x| x.clone())
+        self.processes.get(&id).map(|x| x.0.clone())
     }
 
-    fn add_process(&self, id: u64, proc: Arc<dyn Process>) {
-        self.processes.insert(id, proc);
+    fn add_process(&self, id: u64, proc: Arc<dyn Process>, permit: Option<OwnedSemaphorePermit>) {
+        self.processes.insert(id, (proc, permit));
         #[cfg(all(feature = "metrics", not(feature = "detailed_metrics")))]
         let labels: [(String, String); 0] = [];
         #[cfg(all(feature = "metrics", feature = "detailed_metrics"))]
@@ -81,7 +88,7 @@ impl Environment for LunaticEnvironment {
 
     fn send(&self, id: u64, signal: Signal) {
         if let Some(proc) = self.processes.get(&id) {
-            proc.send(signal);
+            proc.0.send(signal);
         }
     }
 
@@ -91,6 +98,11 @@ impl Environment for LunaticEnvironment {
 
     fn id(&self) -> u64 {
         self.environment_id
+    }
+
+    async fn can_spawn_next_process(&self) -> Result<Option<OwnedSemaphorePermit>> {
+        // Don't impose any limits to process spawning
+        Ok(None)
     }
 }
 

--- a/crates/lunatic-process/src/env.rs
+++ b/crates/lunatic-process/src/env.rs
@@ -99,7 +99,7 @@ impl Environment for LunaticEnvironment {
 
     async fn can_spawn_next_process(&self) -> Result<Option<()>> {
         // Don't impose any limits to process spawning
-        Ok(None)
+        Ok(Some(()))
     }
 }
 

--- a/crates/lunatic-process/src/wasm.rs
+++ b/crates/lunatic-process/src/wasm.rs
@@ -19,7 +19,6 @@ use crate::{Process, Signal, WasmProcess};
 /// After it's spawned the process will keep running in the background. A process can be killed
 /// with `Signal::Kill` signal. If you would like to block until the process is finished you can
 /// `.await` on the returned `JoinHandle<()>`.
-#[allow(clippy::too_many_arguments)]
 pub async fn spawn_wasm<S>(
     env: Arc<dyn Environment>,
     runtime: WasmtimeRuntime,

--- a/crates/lunatic-process/src/wasm.rs
+++ b/crates/lunatic-process/src/wasm.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use log::trace;
-use tokio::sync::OwnedSemaphorePermit;
 use tokio::task::JoinHandle;
 use wasmtime::{ResourceLimiter, Val};
 
@@ -29,7 +28,6 @@ pub async fn spawn_wasm<S>(
     function: &str,
     params: Vec<Val>,
     link: Option<(Option<i64>, Arc<dyn Process>)>,
-    permit: Option<OwnedSemaphorePermit>,
 ) -> Result<(JoinHandle<Result<S>>, Arc<dyn Process>)>
 where
     S: ProcessState + Send + ResourceLimiter + 'static,
@@ -45,7 +43,7 @@ where
     let child_process = crate::new(fut, id, env.clone(), signal_mailbox.1, message_mailbox);
     let child_process_handle = Arc::new(WasmProcess::new(id, signal_mailbox.0.clone()));
 
-    env.add_process(id, child_process_handle.clone(), permit);
+    env.add_process(id, child_process_handle.clone());
 
     // **Child link guarantees**:
     // The link signal is going to be put inside of the child's mailbox and is going to be

--- a/src/mode/cargo_test.rs
+++ b/src/mode/cargo_test.rs
@@ -2,7 +2,11 @@ use std::{collections::HashMap, env, fs, path::Path, sync::Arc, time::Instant};
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use lunatic_process::{env::LunaticEnvironment, runtimes, wasm::spawn_wasm};
+use lunatic_process::{
+    env::{Environment, LunaticEnvironment},
+    runtimes,
+    wasm::spawn_wasm,
+};
 use lunatic_process_api::ProcessConfigCtx;
 use lunatic_runtime::{DefaultProcessConfig, DefaultProcessState};
 use lunatic_stdout_capture::StdoutCapture;
@@ -241,6 +245,7 @@ pub(crate) async fn test(augmented_args: Option<Vec<String>>) -> Result<()> {
         state.set_stdout(stdout.clone());
         state.set_stderr(stdout.clone());
 
+        let spawn_permit = env.can_spawn_next_process().await?;
         let (task, _) = spawn_wasm(
             env,
             runtime.clone(),
@@ -249,6 +254,7 @@ pub(crate) async fn test(augmented_args: Option<Vec<String>>) -> Result<()> {
             &test_function.wasm_export_name,
             Vec::new(),
             None,
+            spawn_permit,
         )
         .await
         .context(format!(

--- a/src/mode/cargo_test.rs
+++ b/src/mode/cargo_test.rs
@@ -245,7 +245,7 @@ pub(crate) async fn test(augmented_args: Option<Vec<String>>) -> Result<()> {
         state.set_stdout(stdout.clone());
         state.set_stderr(stdout.clone());
 
-        let spawn_permit = env.can_spawn_next_process().await?;
+        env.can_spawn_next_process().await?;
         let (task, _) = spawn_wasm(
             env,
             runtime.clone(),
@@ -254,7 +254,6 @@ pub(crate) async fn test(augmented_args: Option<Vec<String>>) -> Result<()> {
             &test_function.wasm_export_name,
             Vec::new(),
             None,
-            spawn_permit,
         )
         .await
         .context(format!(

--- a/src/mode/common.rs
+++ b/src/mode/common.rs
@@ -5,7 +5,7 @@ use clap::Args;
 
 use lunatic_distributed::DistributedProcessState;
 use lunatic_process::{
-    env::{LunaticEnvironment, LunaticEnvironments},
+    env::{Environment, LunaticEnvironment, LunaticEnvironments},
     runtimes::{wasmtime::WasmtimeRuntime, RawWasm},
     wasm::spawn_wasm,
 };
@@ -75,6 +75,7 @@ pub async fn run_wasm(args: RunWasm) -> Result<()> {
     )
     .unwrap();
 
+    let spawn_permit = args.env.can_spawn_next_process().await?;
     let (task, _) = spawn_wasm(
         args.env,
         args.runtime,
@@ -83,6 +84,7 @@ pub async fn run_wasm(args: RunWasm) -> Result<()> {
         "_start",
         Vec::new(),
         None,
+        spawn_permit,
     )
     .await
     .context(format!(

--- a/src/mode/common.rs
+++ b/src/mode/common.rs
@@ -75,7 +75,7 @@ pub async fn run_wasm(args: RunWasm) -> Result<()> {
     )
     .unwrap();
 
-    let spawn_permit = args.env.can_spawn_next_process().await?;
+    args.env.can_spawn_next_process().await?;
     let (task, _) = spawn_wasm(
         args.env,
         args.runtime,
@@ -84,7 +84,6 @@ pub async fn run_wasm(args: RunWasm) -> Result<()> {
         "_start",
         Vec::new(),
         None,
-        spawn_permit,
     )
     .await
     .context(format!(

--- a/src/state.rs
+++ b/src/state.rs
@@ -514,19 +514,10 @@ mod tests {
         )
         .unwrap();
 
-        let spawn_permit = env.can_spawn_next_process().await.unwrap();
+        env.can_spawn_next_process().await.unwrap();
 
-        spawn_wasm(
-            env,
-            runtime,
-            &module,
-            state,
-            "hello",
-            Vec::new(),
-            None,
-            spawn_permit,
-        )
-        .await
-        .unwrap();
+        spawn_wasm(env, runtime, &module, state, "hello", Vec::new(), None)
+            .await
+            .unwrap();
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -479,6 +479,7 @@ impl DistributedCtx<LunaticEnvironment> for DefaultProcessState {
 }
 
 mod tests {
+
     #[tokio::test]
     async fn import_filter_signature_matches() {
         use std::collections::HashMap;
@@ -486,6 +487,7 @@ mod tests {
 
         use crate::state::DefaultProcessState;
         use crate::DefaultProcessConfig;
+        use lunatic_process::env::Environment;
         use lunatic_process::runtimes::wasmtime::WasmtimeRuntime;
         use lunatic_process::wasm::spawn_wasm;
         use std::sync::Arc;
@@ -512,8 +514,19 @@ mod tests {
         )
         .unwrap();
 
-        spawn_wasm(env, runtime, &module, state, "hello", Vec::new(), None)
-            .await
-            .unwrap();
+        let spawn_permit = env.can_spawn_next_process().await.unwrap();
+
+        spawn_wasm(
+            env,
+            runtime,
+            &module,
+            state,
+            "hello",
+            Vec::new(),
+            None,
+            spawn_permit,
+        )
+        .await
+        .unwrap();
     }
 }


### PR DESCRIPTION
This change add `can_spawn_next_process` function to the Environment.
Currently the default implementation always returns a unit type which does not impose limits to spawning a new process.