### PR TITLE
Show registered process name in trap warning messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "lunatic-networking-api",
  "metrics",
  "serde",
+ "smallvec",
  "tokio",
  "wasmtime",
  "wasmtime-wasi",

--- a/crates/lunatic-distributed/src/distributed/server.rs
+++ b/crates/lunatic-distributed/src/distributed/server.rs
@@ -67,7 +67,7 @@ pub async fn node_server<T, E>(
     key: String,
 ) -> Result<()>
 where
-    T: ProcessState + ResourceLimiter + DistributedCtx<E> + Send + 'static,
+    T: ProcessState + ResourceLimiter + DistributedCtx<E> + Send + Sync + 'static,
     E: Environment + 'static,
 {
     let mut quic_server = quic::new_quic_server(socket, &cert, &key, &ca_cert)?;
@@ -83,7 +83,7 @@ pub async fn handle_message<T, E>(
     msg_id: u64,
     msg: Request,
 ) where
-    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + 'static,
+    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + Sync + 'static,
     E: Environment + 'static,
 {
     if let Err(e) = handle_message_err(ctx, send, msg_id, msg).await {
@@ -98,7 +98,7 @@ async fn handle_message_err<T, E>(
     msg: Request,
 ) -> Result<()>
 where
-    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + 'static,
+    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + Sync + 'static,
     E: Environment + 'static,
 {
     match msg {
@@ -143,7 +143,7 @@ where
 
 async fn handle_spawn<T, E>(ctx: ServerCtx<T, E>, spawn: Spawn) -> Result<Result<u64, ClientError>>
 where
-    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + 'static,
+    T: ProcessState + DistributedCtx<E> + ResourceLimiter + Send + Sync + 'static,
     E: Environment + 'static,
 {
     let Spawn {

--- a/crates/lunatic-distributed/src/quic/quin.rs
+++ b/crates/lunatic-distributed/src/quic/quin.rs
@@ -146,7 +146,7 @@ pub async fn handle_node_server<T, E>(
     ctx: distributed::server::ServerCtx<T, E>,
 ) -> Result<()>
 where
-    T: ProcessState + ResourceLimiter + DistributedCtx<E> + Send + 'static,
+    T: ProcessState + ResourceLimiter + DistributedCtx<E> + Send + Sync + 'static,
     E: Environment + 'static,
 {
     while let Some(conn) = quic_server.accept().await {
@@ -160,7 +160,7 @@ async fn handle_quic_connection_node<T, E>(
     conn: Connecting,
 ) -> Result<()>
 where
-    T: ProcessState + ResourceLimiter + DistributedCtx<E> + Send + 'static,
+    T: ProcessState + ResourceLimiter + DistributedCtx<E> + Send + Sync + 'static,
     E: Environment + 'static,
 {
     log::info!("New node connection");
@@ -192,7 +192,7 @@ async fn handle_quic_stream_node<T, E>(
     mut send: SendStream,
     mut recv: RecvStream,
 ) where
-    T: ProcessState + ResourceLimiter + DistributedCtx<E> + Send + 'static,
+    T: ProcessState + ResourceLimiter + DistributedCtx<E> + Send + Sync + 'static,
     E: Environment + 'static,
 {
     while let Ok(bytes) = recv.receive().await {

--- a/crates/lunatic-process-api/src/lib.rs
+++ b/crates/lunatic-process-api/src/lib.rs
@@ -46,7 +46,14 @@ pub trait ProcessCtx<S: ProcessState> {
 // Register the process APIs to the linker
 pub fn register<T>(linker: &mut Linker<T>) -> Result<()>
 where
-    T: ProcessState + ProcessCtx<T> + ErrorCtx + LunaticWasiCtx + Send + ResourceLimiter + 'static,
+    T: ProcessState
+        + ProcessCtx<T>
+        + ErrorCtx
+        + LunaticWasiCtx
+        + Send
+        + Sync
+        + ResourceLimiter
+        + 'static,
     for<'a> &'a T: Send,
     T::Config: ProcessConfigCtx,
 {
@@ -534,7 +541,14 @@ fn spawn<T>(
     id_ptr: u32,
 ) -> Box<dyn Future<Output = Result<u32>> + Send + '_>
 where
-    T: ProcessState + ProcessCtx<T> + ErrorCtx + LunaticWasiCtx + ResourceLimiter + Send + 'static,
+    T: ProcessState
+        + ProcessCtx<T>
+        + ErrorCtx
+        + LunaticWasiCtx
+        + ResourceLimiter
+        + Send
+        + Sync
+        + 'static,
     for<'a> &'a T: Send,
     T::Config: ProcessConfigCtx,
 {

--- a/crates/lunatic-process/Cargo.toml
+++ b/crates/lunatic-process/Cargo.toml
@@ -23,6 +23,7 @@ dashmap = { workspace = true }
 log = { workspace = true }
 metrics = { workspace = true, optional = true }
 serde = { workspace = true }
+smallvec = "1.10"
 tokio = { workspace = true, features = [
   "macros",
   "rt-multi-thread",

--- a/crates/lunatic-process/src/lib.rs
+++ b/crates/lunatic-process/src/lib.rs
@@ -440,19 +440,6 @@ pub struct NativeProcess {
 }
 
 /// Spawns a process from a closure.
-///
-/// ## Example:
-///
-/// ```no_run,ignore
-/// use std::sync::Arc;
-/// let env = Arc::new(lunatic_process::env::LunaticEnvironment::new(1));
-/// let _proc = lunatic_process::spawn(env, |_this, mailbox| async move {
-///     // Wait on a message with the tag `27`.
-///     mailbox.pop(Some(&[27])).await;
-///     // TODO: Needs to return ExecutionResult. Probably the `new` function will need to be adjusted
-///     Ok(())
-/// });
-/// ```
 pub fn spawn<T, F, K, R>(
     env: Arc<dyn Environment>,
     func: F,

--- a/crates/lunatic-process/src/lib.rs
+++ b/crates/lunatic-process/src/lib.rs
@@ -443,7 +443,7 @@ pub struct NativeProcess {
 ///
 /// ## Example:
 ///
-/// ```no_run
+/// ```no_run,ignore
 /// use std::sync::Arc;
 /// let env = Arc::new(lunatic_process::env::LunaticEnvironment::new(1));
 /// let _proc = lunatic_process::spawn(env, |_this, mailbox| async move {
@@ -453,7 +453,6 @@ pub struct NativeProcess {
 ///     Ok(())
 /// });
 /// ```
-
 pub fn spawn<T, F, K, R>(
     env: Arc<dyn Environment>,
     func: F,

--- a/crates/lunatic-process/src/wasm.rs
+++ b/crates/lunatic-process/src/wasm.rs
@@ -29,7 +29,7 @@ pub async fn spawn_wasm<S>(
     link: Option<(Option<i64>, Arc<dyn Process>)>,
 ) -> Result<(JoinHandle<Result<S>>, Arc<dyn Process>)>
 where
-    S: ProcessState + Send + ResourceLimiter + 'static,
+    S: ProcessState + Send + Sync + ResourceLimiter + 'static,
 {
     let id = state.id();
     trace!("Spawning process: {}", id);


### PR DESCRIPTION
Fixes https://github.com/lunatic-solutions/lunatic/issues/124
Depends on https://github.com/lunatic-solutions/lunatic-rs/pull/100

Looks up the process name in the registry to provide better logging when a process fails.
It uses the process naming conventioned mentioned in https://github.com/lunatic-solutions/lunatic-rs/pull/100.

**This does not check for node_id when looking for registered process name, only process_id.** Is this a problem? I wasn't sure how to get the node of the process.