### PR TITLE
Fix clippy lints for examples, tests, and benches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       # Rust builds can take some time, cache them.
       - uses: Swatinem/rust-cache@v2
       - name: "Run clippy check"
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --examples --tests --benches -- -D warnings
       - name: "Check formatting"
         run: cargo fmt -- --check
       - name: "Run tests"

--- a/src/config.rs
+++ b/src/config.rs
@@ -247,17 +247,17 @@ mod tests {
         let guest_api =
             get_absolute_path(Path::new("crates/lunatic-sqlite-api/src/guest_api")).unwrap();
         // checks that there's no access to any ancestor paths
-        assert_eq!(path_is_ancestor(&guest_api, &crates), false);
-        assert_eq!(path_is_ancestor(&guest_api, &sqlite), false);
-        assert_eq!(path_is_ancestor(&guest_api, &src), false);
+        assert!(!path_is_ancestor(&guest_api, &crates));
+        assert!(!path_is_ancestor(&guest_api, &sqlite));
+        assert!(!path_is_ancestor(&guest_api, &src));
     }
 
     #[test]
     fn test_forbidden_absolute_paths() {
         let src = get_absolute_path(Path::new("crates/lunatic-sqlite-api/src")).unwrap();
         // checks that there's no access to any ancestor paths
-        assert_eq!(path_is_ancestor(&src, Path::new("/")), false);
-        assert_eq!(path_is_ancestor(&src, Path::new("/etc/passwd")), false);
+        assert!(!path_is_ancestor(&src, Path::new("/")));
+        assert!(!path_is_ancestor(&src, Path::new("/etc/passwd")));
     }
 
     #[test]


### PR DESCRIPTION
Fixed some clippy lints in config tests, and added some cli flags to the clippy ci.