### PR TITLE
Conventional commits changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,32 @@ To run the tests:
 cargo test
 ```
 
+## Changelog generation
+
+The changelog is updated using the [git-cliff](https://git-cliff.org/) cli,
+which generates the changelog file from the [Git](https://git-scm.com/) history by utilizing [conventional commits](https://git-cliff.org/#conventional_commits).
+
+The changelog template is defined in [Cargo.toml](/Cargo.toml) under `[workspace.metadata.git-cliff.*]`.
+
+Updating the CHANGELOG.md file can be achieved with the following command:
+
+```bash
+git cliff --config ./Cargo.toml --latest --prepend ./CHANGELOG.md
+```
+
+The commit types are as follows:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **perf**: A code change that improves performance
+* **test**: Adding missing or correcting existing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
+
+For more information, see the [git-cliff usage documentation](https://git-cliff.org/#usage).
+
 ## Useful resources
 - [Project Loom on virtual threads](https://cr.openjdk.org/~rpressler/loom/loom/sol1_part1.html)
 - [Erlang documentation](https://www.erlang.org/docs) - these explain some concepts that Lunatic implements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,3 +137,27 @@ wasi-common = "6"
 wasmtime = "6"
 wasmtime-wasi = "6"
 wiggle = "6"
+
+[workspace.metadata.git-cliff.changelog]
+header = """
+# Lunatic Changelog
+
+"""
+
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}]
+
+    Released {{ timestamp | date(format="%Y-%m-%d") }}.
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }} _([{{ commit.author.name }}](https://github.com/lunatic-solutions/lunatic/commit/{{ commit.id | urlencode }}))_\
+    {% endfor %}
+{% endfor %}\n
+"""
+
+footer = ""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | upper_first }}
     {% for commit in commits %}
-        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }} _([{{ commit.author.name }}](https://github.com/lunatic-solutions/lunatic/commit/{{ commit.id | urlencode }}))_\
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }} [`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/lunatic-solutions/lunatic/commit/{{ commit.id | urlencode }})\
     {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
## Changelog generation

The changelog is updated using the [git-cliff](https://git-cliff.org/) cli, which generates the changelog file from the [Git](https://git-scm.com/) history by utilizing [conventional commits](https://git-cliff.org/#conventional_commits).

The changelog template is defined in [Cargo.toml](/Cargo.toml) under `[workspace.metadata.git-cliff.*]`.

Updating the CHANGELOG.md file can be achieved with the following command:

```bash
git cliff --config ./Cargo.toml --latest --prepend ./CHANGELOG.md
```

The commit types are as follows:

* **feat**: A new feature
* **fix**: A bug fix
* **docs**: Documentation only changes
* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* **refactor**: A code change that neither fixes a bug nor adds a feature
* **perf**: A code change that improves performance
* **test**: Adding missing or correcting existing tests
* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation

For more information, see the [git-cliff usage documentation](https://git-cliff.org/#usage).

---

Note, the current commits don't follow the conventional commits spec, so the next changelog will likely have to be done manually still. But after the next tag is released, if we stick to conventional commit messages, future changelogs can be generated and prepended to the `CHANGELOG.md` file as described in the command above.

Contributors are not required to adhere to the conventional commit spec, but if we merge any PRs, we should consolidate the commits into a single conventional commit message.

I could add CI integration for generating the changelog, though I'm not sure if its preferred we run the command manually upon creating a new release.