### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "An actor platform built on WebAssembly"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic"
 categories = ["wasm"]
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 readme = "README.md"
 default-run = "lunatic"
 

--- a/crates/hash-map-id/Cargo.toml
+++ b/crates/hash-map-id/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 description = "HashMap wrapper with incremental ID (u64) as key"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/hash-map-id"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]

--- a/crates/lunatic-common-api/Cargo.toml
+++ b/crates/lunatic-common-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Common functionality for building lunatic host function APIs."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-common-api"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/lunatic-control-axum/Cargo.toml
+++ b/crates/lunatic-control-axum/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "TBD"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 lunatic-control = { workspace = true }

--- a/crates/lunatic-control-submillisecond/Cargo.toml
+++ b/crates/lunatic-control-submillisecond/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "TBD"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 lunatic-control = { path = "../lunatic-control" }

--- a/crates/lunatic-control/Cargo.toml
+++ b/crates/lunatic-control/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "TBD"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/crates/lunatic-distributed-api/Cargo.toml
+++ b/crates/lunatic-distributed-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "A simple control server implementation"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 lunatic-common-api = { workspace = true }

--- a/crates/lunatic-distributed/Cargo.toml
+++ b/crates/lunatic-distributed/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Node to node communication"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 lunatic-control = { workspace = true }

--- a/crates/lunatic-error-api/Cargo.toml
+++ b/crates/lunatic-error-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions that make dealing with Anyhow errors simpler."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 hash-map-id = { workspace = true }

--- a/crates/lunatic-messaging-api/Cargo.toml
+++ b/crates/lunatic-messaging-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions for message sending."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-messaging-api"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 lunatic-common-api = { workspace = true }

--- a/crates/lunatic-metrics-api/Cargo.toml
+++ b/crates/lunatic-metrics-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions for metrics"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-metrics"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/lunatic-networking-api/Cargo.toml
+++ b/crates/lunatic-networking-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions for tcp and udp networking."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-networking-api"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 hash-map-id = { workspace = true }

--- a/crates/lunatic-process-api/Cargo.toml
+++ b/crates/lunatic-process-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions for working with processes."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-process-api"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [features]
 metrics = ["dep:metrics"]

--- a/crates/lunatic-process/Cargo.toml
+++ b/crates/lunatic-process/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic's core process, mailbox and message abstraction'"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-process"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [features]
 metrics = ["dep:metrics"]

--- a/crates/lunatic-registry-api/Cargo.toml
+++ b/crates/lunatic-registry-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions for registering named processes."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [features]
 metrics = ["dep:metrics"]

--- a/crates/lunatic-sqlite-api/Cargo.toml
+++ b/crates/lunatic-sqlite-api/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Lunatic host functions for sqlite."
 edition = "2021"
 homepage = "https://lunatic.solutions"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 name = "lunatic-sqlite-api"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-sqlite-api"
 version = "0.13.3"

--- a/crates/lunatic-stdout-capture/Cargo.toml
+++ b/crates/lunatic-stdout-capture/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Helper library for holding stdout streams of lunatic processes."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-registry-api"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 wasi-common = { workspace = true }

--- a/crates/lunatic-timer-api/Cargo.toml
+++ b/crates/lunatic-timer-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions for working with timers."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-timer-api"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [features]
 metrics = ["dep:metrics"]

--- a/crates/lunatic-trap-api/Cargo.toml
+++ b/crates/lunatic-trap-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions for catching traps."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 lunatic-common-api = { workspace = true }

--- a/crates/lunatic-version-api/Cargo.toml
+++ b/crates/lunatic-version-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions for getting Lunatic host version"
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-version-api"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/lunatic-wasi-api/Cargo.toml
+++ b/crates/lunatic-wasi-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Lunatic host functions for WASI."
 homepage = "https://lunatic.solutions"
 repository = "https://github.com/lunatic-solutions/lunatic/tree/main/crates/lunatic-wasi-api"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 lunatic-common-api = { workspace = true }


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields